### PR TITLE
Documentation of how to use modules with CommonJS syntax or in CoffeeScript

### DIFF
--- a/Contributing.md
+++ b/Contributing.md
@@ -8,9 +8,21 @@ The simplest way to contribute to a project is to open an issue or a pull reques
  - Meteor Guide: https://github.com/meteor/guide/issues
  - Meteor Tutorials : https://github.com/meteor/tutorials/issues
 
-### Pull Requests
+## Issues
 
-We welcome changes both large and small. Larger changes may require some discussion and buy in from the documentation maintainers before being accepted—if you are unsure, it may be sensible to open an issue discussing the changes before making them.
+If you see a problem with a particular piece of content, you can hit the "Edit on GitHub" button to jump straight to the file on GitHub. If you are keen, you can submit a Pull Request immediately to fix the problem; alternatively, hit the "Issues" button at the top to open an issue reporting the problem.
+
+## Pull Requests
+
+We welcome changes both large and small.
+
+### Small changes
+
+Smaller changes such as fixing typos and small edits for clarity will typically be merged quickly, and are very helpful! Contributions like this enable us to maintain our high quality of documentation
+
+### Larger changes
+
+Larger changes like section rewrites, new sections and even entirely new articles are also encouraged! In fact some large parts of our documentation have been contributed by community members. However, more controversial larger changes may require some discussion and buy in from the documentation maintainers before being accepted—if you are unsure, it may be sensible to open an issue discussing the changes before making them.
 
 ### Becoming a documentation maintainer
 

--- a/scripts/api-box.js
+++ b/scripts/api-box.js
@@ -31,7 +31,7 @@ hexo.extend.tag.register('apibox', function(args) {
 
   data.id = data.longname.replace(/[.#]/g, "-");
 
-  data.signature = signature(data, { short: false});
+  data.signature = signature(data, { short: false });
   data.title = signature(data, {
     short: true,
     instanceDelimiter: data.instanceDelimiter,
@@ -123,6 +123,13 @@ signature = function (data, options) {
     } else if (data.scope === "instance" && options.short) {
       // Something#foo => #foo
       return '<em>' + options.instanceDelimiter + '</em>' + escapedLongname.split('#')[1];
+    }
+
+    // If the user passes in a instanceDelimiter and we are a static method,
+    // we are probably underneath a heading that defines the object (e.g. DDPRateLimiter)
+    if (data.scope === "static" && options.instanceDelimiter && options.short) {
+      // Something.foo => .foo
+      return '<em>' + options.instanceDelimiter + '</em>' + escapedLongname.split('.')[1];
     }
 
     return escapedLongname + paramsStr;

--- a/source/api/collections.md
+++ b/source/api/collections.md
@@ -1,7 +1,7 @@
 ---
 title: Collections
 order: 6
-description: Documentaton on how to use Meteor's database collections.
+description: Documentation on how to use Meteor's database collections.
 ---
 
 Meteor stores data in *collections*.  To get started, declare a

--- a/source/api/methods.md
+++ b/source/api/methods.md
@@ -194,7 +194,7 @@ limits login attempts, new user creation, and password resets to 5 attempts
 every 10 seconds per connection. It can be removed by calling
 `Accounts.removeDefaultRateLimit()`.
 
-{% apibox "DDPRateLimiter.addRule" nested:true %}
+{% apibox "DDPRateLimiter.addRule" nested:true instanceDelimiter:. %}
 
 Custom rules can be added by calling `DDPRateLimiter.addRule`. The rate
 limiter is called on every method and subscription invocation.
@@ -218,5 +218,5 @@ var loginRule = {
 // Add the rule, allowing up to 5 messages every 1000 milliseconds.
 DDPRateLimiter.addRule(loginRule, 5, 1000);
 ```
-{% apibox "DDPRateLimiter.removeRule" nested:true %}
-{% apibox "DDPRateLimiter.setErrorMessage" nested:true %}
+{% apibox "DDPRateLimiter.removeRule" nested:true instanceDelimiter:. %}
+{% apibox "DDPRateLimiter.setErrorMessage" nested:true instanceDelimiter:. %}

--- a/source/api/packagejs.md
+++ b/source/api/packagejs.md
@@ -33,10 +33,10 @@ Package.onUse(function (api) {
   // Use Underscore package, but only on the server.
   // Version not specified, so it will be as of Meteor 0.9.0.
   api.use('underscore', 'server');
-  // Use iron:router package, version 1.0.0 or newer.
-  api.use('iron:router@1.0.0');
-  // Give users of this package access to the Templating package.
-  api.imply('templating')
+  // Use kadira:flow-router, version 1.0.0 or newer.
+  api.use('kadira:flow-router@2.12.1');
+  // Give users of this package access to active-route's Javascript helpers
+  api.imply('zimme:active-route@2.3.2')
   // Export the object 'Email' to packages or apps that use this package.
   api.export('Email', 'server');
   // Specify the source code for the package.
@@ -47,13 +47,13 @@ Package.onUse(function (api) {
 Package.onTest(function (api) {
   // Sets up a dependency on this package
   api.use('username:package-name');
-  // Allows you to use the 'tinytest' framework
-  api.use('tinytest@1.0.0');
+  // Allows you to use the mocha test framework
+  api.use('practicalmeteor:mocha@2.4.5_2');
   // Specify the source code for the package tests
   api.addFiles('email_tests.js', 'server');
 });
 
-/* This lets you use npm packages in your package*/
+/* This lets you use npm packages in your package */
 Npm.depends({
   simplesmtp: "0.3.10",
   "stream-buffers": "0.2.5"});

--- a/source/packages/coffeescript.md
+++ b/source/packages/coffeescript.md
@@ -22,8 +22,7 @@ Here's how CoffeeScript works with Meteor's namespacing.
   they are defined.)
 
 * When writing a package, CoffeeScript-defined variables can be
-  exported like any other variable (see [Writing
-  Packages](#writingpackages)). Exporting a variable pulls it up to
+  exported like any other variable (see [Package.js](/api/packagejs.html)). Exporting a variable pulls it up to
   package scope, meaning that it will be visible to all of the code in
   your app or package (both `.js` and `.coffee` files).
 
@@ -49,3 +48,7 @@ Here's how CoffeeScript works with Meteor's namespacing.
 Heavy CoffeeScript users, please let us know how this arrangement
 works for you, whether `share` is helpful for you, and anything else
 you'd like to see changed.
+
+### Modules and CoffeeScript
+
+See [Modules » Syntax » CoffeeScript](/packages/modules.html#CoffeeScript).

--- a/source/packages/modules.md
+++ b/source/packages/modules.md
@@ -20,6 +20,8 @@ While the `modules` package is useful by itself, we very much encourage using th
 
 ## Basic syntax
 
+### ES2015
+
 Although there are a number of different variations of `import` and `export` syntax, this section describes the essential forms that everyone should know.
 
 First, you can `export` any named declaration on the same line where it was declared:
@@ -99,6 +101,93 @@ import {default as Value, a, F} from "./exporter";
 ```
 
 These examples should get you started with `import` and `export` syntax. For further reading, here is a very detailed [explanation](http://www.2ality.com/2014/09/es6-modules-final.html) by [Axel Rauschmayer](https://twitter.com/rauschma) of every variation of `import` and `export` syntax.
+
+### CommonJS
+
+You don’t need to use the `ecmascript` package or ES2015 syntax in order to use modules. Just like Node.js in the pre-ES2015 days, you can use `require` and `module.exports`—that’s what the `import` and `export` statements are compiling into, anyway.
+
+ES2015 `import` lines like these:
+
+```js
+import { AccountsTemplates } from 'meteor/useraccounts:core';
+import '../imports/startup/client/routes.js';
+```
+
+can be written with CommonJS like this:
+
+```js
+var UserAccountsCore = require('meteor/useraccounts:core');
+require('../imports/startup/client/routes.js');
+```
+
+and you can access `AccountsTemplates` via `UserAccountsCore.AccountsTemplates`.
+
+Note that files don’t need a `module.exports` if they’re required like `routes.js` is in this example, without assignment to any variable. The code in `routes.js` will simply be included and executed in place of the above `require` statement.
+
+ES2015 `export` statements like these:
+
+```js
+export const insert = new ValidatedMethod({ // ...
+export default incompleteCountDenormalizer;
+```
+
+can be rewritten to use CommonJS `module.exports`:
+
+```js
+module.exports.insert = new ValidatedMethod({ // ...
+module.exports.default = incompleteCountDenormalizer;
+```
+
+You can also simply write `exports` instead of `module.exports` if you prefer. If you need to `require` from an ES2015 module with a `default` export, you can access the export with `require("package").default`.
+
+There is a case where you might *need* to use CommonJS, even if your project has the `ecmascript` package: if you want to conditionally include a module. `import` statements must be at top-level scope, so they cannot be within an `if` block. If you’re writing a common file, loaded on both client and server, you might want to import a module in only one or the other environment:
+
+```js
+if (Meteor.isClient) {
+  require('./client-only-file.js');
+}
+```
+
+Note that dynamic calls to `require()` (where the name being required can change at runtime) cannot be analyzed correctly and may result in broken client bundles. This is also discussed in [the guide](http://guide.meteor.com/structure.html#using-require).
+
+### CoffeeScript
+
+CoffeeScript has been a first-class supported language since Meteor’s early days. Even though today we recommend ES2015, we still intend to support CoffeeScript fully.
+
+CoffeeScript lacks support for `import` and `export`, though [the project maintainers are in the early stages of working to change that](https://github.com/jashkenas/coffeescript/issues/4078). In the meantime, CoffeeScript users can enjoy Meteor’s new modules support by using CommonJS syntax. If you use CoffeeScript’s [destructuring](http://coffeescript.org/#destructuring), the syntax is remarkably similar to the ES2015 examples you see above. For example, ES2015 `import` lines like these:
+
+```js
+import { AccountsTemplates } from 'meteor/useraccounts:core';
+import '../imports/startup/client/routes.js';
+```
+
+can be written in CoffeeScript using CommonJS `require` like this:
+
+```coffeescript
+{ AccountsTemplates } = require 'meteor/useraccounts:core'
+require '../imports/startup/client/routes.coffee'
+```
+
+(assuming you rename `routes.js` to `routes.coffee`). Note that files don’t need a `module.exports` if they’re required like `routes.coffee` is in this example, without assignment to any variable. The code in `routes.coffee` will simply be included and executed in place of the above `require` statement.
+
+ES2015 `export` statements like these:
+
+```js
+export const insert = new ValidatedMethod({ // ...
+export default incompleteCountDenormalizer;
+```
+
+can be rewritten to use CommonJS `module.exports`:
+
+```coffeescript
+module.exports.insert = new ValidatedMethod # ...
+module.exports = incompleteCountDenormalizer
+```
+
+You can also simply write `exports` instead of `module.exports` if you prefer.
+
+Note that [backticks](http://coffeescript.org/#embedded) do *[not](https://github.com/meteor/meteor/issues/6000)* work; your `.coffee` files will be transpiled into JavaScript, but not then handed off to the `ecmascript` package for further transpiling. Any JavaScript you type in backticks will be passed through unmodified all the way to the browser or Node.js runtime.
+
 
 ## Modular application structure
 

--- a/source/packages/modules.md
+++ b/source/packages/modules.md
@@ -186,7 +186,7 @@ module.exports = incompleteCountDenormalizer
 
 You can also simply write `exports` instead of `module.exports` if you prefer.
 
-Note that [backticks](http://coffeescript.org/#embedded) do *[not](https://github.com/meteor/meteor/issues/6000)* work; your `.coffee` files will be transpiled into JavaScript, but not then handed off to the `ecmascript` package for further transpiling. Any JavaScript you type in backticks will be passed through unmodified all the way to the browser or Node.js runtime.
+Note that ES2015 code in [backticks](http://coffeescript.org/#embedded), for example an `import` statement in backticks, do *[not](https://github.com/meteor/meteor/issues/6000)* work; your `.coffee` files will be transpiled into JavaScript, but not then handed off to the `ecmascript` package for further transpiling. Any JavaScript you type in backticks will be passed through unmodified all the way to the browser or Node.js runtime.
 
 
 ## Modular application structure


### PR DESCRIPTION
Okay, one last time! Moving here from https://github.com/meteor/meteor/pull/6636.

This PR expands the Modules » Syntax section to include subsections for CommonJS and CoffeeScript syntax. There’s a bit of repetition between the two, since CoffeeScript is just compiling into CommonJS, but I think we should keep the duplication since I doubt most people would read the syntax section that doesn’t apply to them. I also cribbed a little from the [CommonJS section of the Guide](http://guide.meteor.com/structure.html#using-require); I’m not sure what should go here versus there. If anything I think the CommonJS discussion is probably better off here, if the point of the Guide is to explain recommended practices (which obviously CommonJS is not). The caveat that the Guide points out, about how CommonJS is required (sorry, I can’t believe I just made a JavaScript pun) when importing within an `if` block, I would think is probably best explained in the docs and linked to from the Guide.

Also the end of the CoffeeScript section includes a warning about backticks. If https://github.com/meteor/meteor/pull/6691 is merged, we will have to remember to come back here and remove the warning.