### PR TITLE
Explain that `Assets` does not need to be imported

### DIFF
--- a/source/api/assets.md
+++ b/source/api/assets.md
@@ -4,6 +4,8 @@ order: 18
 description: Documentation of how to use assets in Meteor.
 ---
 
+> Currently, it is not possible to import `Assets` as an ES6 module.  Any of the `Assets` methods below can simply be called directly in any Meteor server code.
+
 `Assets` allows server code in a Meteor application to access static server
 assets, which are located in the `private` subdirectory of an application's
 tree. Assets are not processed as source files and are copied directly


### PR DESCRIPTION
meteor/meteor#6784 brought this up.  Since it's different than almost every other Meteor package, it should probably be explained that it's one of the two exceptions (Npm is the other)