### PR TITLE
Added "raw" wrapper around tags from #21

### DIFF
--- a/source/packages/accounts-ui.md
+++ b/source/packages/accounts-ui.md
@@ -11,16 +11,16 @@ To add Accounts and a set of login controls to an application, add the
 `accounts-password`, `accounts-facebook`, `accounts-github`,
 `accounts-google`, `accounts-twitter`, or `accounts-weibo`.
 
-Then simply add the `{{> loginButtons}}` helper to an HTML file. This
+Then simply add the `{% raw %}{{> loginButtons}}{% endraw %}` helper to an HTML file. This
 will place a login widget on the page. If there is only one provider configured
 and it is an external service, this will add a login/logout button. If you use
 `accounts-password` or use multiple external login services, this will add
 a "Sign in" link which opens a dropdown menu with login options. If you plan to
 position the login dropdown in the right edge of the screen, use
-`{{> loginButtons align="right"}}` in order to get the dropdown to lay
+`{% raw %}{{> loginButtons align="right"}}{% endraw %}` in order to get the dropdown to lay
 itself out without expanding off the edge of the screen.
 
-To configure the behavior of `{{> loginButtons}}`, use
+To configure the behavior of `{% raw %}{{> loginButtons}}{% endraw %}`, use
 [`Accounts.ui.config`](#accounts_ui_config).
 
 `accounts-ui` also includes modal popup dialogs to handle links from


### PR DESCRIPTION
TIL that I need to `{% raw %}` and `{% endraw %}` any Blaze template includes because of the `>`.  Fixes breaking change in #21 that prevents hexo server from starting (even though I thought I tried it with `hexo server` previously).