### PR TITLE
Fix some grammar

### DIFF
--- a/source/api/passwords.md
+++ b/source/api/passwords.md
@@ -50,7 +50,7 @@ insensitive duplicates before updates.
 
 By default, an email address is added with `{ verified: false }`. Use
 [`Accounts.sendVerificationEmail`](#Accounts-sendVerificationEmail) to send an
-email with a link the user can use verify their email address.
+email with a link the user can use to verify their email address.
 
 {% apibox "Accounts.removeEmail" %}
 


### PR DESCRIPTION
This is a tiny grammar fix for the `Accounts.sendVerificationEmail` section of API docs.

It says _Send an email with a link the user can use verify their email address._

IMO it should say _Send an email with a link the user can use to verify their email address._