### PR TITLE
Add resetPassword example

### DIFF
--- a/source/api/passwords.md
+++ b/source/api/passwords.md
@@ -163,4 +163,8 @@ Accounts.emailTemplates.enrollAccount.text = function (user, url) {
      + " To activate your account, simply click the link below:\n\n"
      + url;
 };
+Accounts.emailTemplates.resetPassword.from = function () {
+   // Overrides value set in Accounts.emailTemplates.from for this template
+   return "AwesomeSite Password Reset <no-reply@example.com>";
+};
 ```


### PR DESCRIPTION
Provides clarification between Accounts.emailTemplates.from, which takes a string, and Accounts.emailTemplates.resetPassword.from, which takes a function.