### PR TITLE
Use apibox to reference Random functions

### DIFF
--- a/source/packages/random.md
+++ b/source/packages/random.md
@@ -11,30 +11,8 @@ cryptographically strong randomness is not available (on older browsers or on
 servers that don't have enough entropy to seed the cryptographically strong
 generator).
 
-<dl class="callbacks">
-{% dtdd name:"Random.id([n])" %}
-Returns a unique identifier, such as `"Jjwjg6gouWLXhMGKW"`, that is
-likely to be unique in the whole world. The optional argument `n`
-specifies the length of the identifier in characters and defaults to 17.
-{% enddtdd %}}
-
-{% dtdd name:"Random.secret([n])" %}
-Returns a random string of printable characters with 6 bits of
-entropy per character. The optional argument `n` specifies the length of
-the secret string and defaults to 43 characters, or 256 bits of
-entropy. Use `Random.secret` for security-critical secrets that are
-intended for machine, rather than human, consumption.
-{% enddtdd %}}
-
-{% dtdd name:"Random.fraction()" %}
-Returns a number between 0 and 1, like `Math.random`.
-{% enddtdd %}}
-
-{% dtdd name:"Random.choice(arrayOrString)" %}
-Returns a random element of the given array or string.
-{% enddtdd %}}
-
-{% dtdd name:"Random.hexString(n)" %}
-Returns a random string of `n` hexadecimal digits.
-{% enddtdd %}}
-</dl>
+{% apibox "Random.id" %}
+{% apibox "Random.secret" %}
+{% apibox "Random.fraction" %}
+{% apibox "Random.choice" %}
+{% apibox "Random.hexString" %}


### PR DESCRIPTION
Uses `apibox` to reference functions from the _random_ package to get better formatting (like the rest of the docs). Currently, the layout looks wrong: http://docs.meteor.com/packages/random.html

Based on https://github.com/meteor/meteor/pull/7216