### PR TITLE
Put space between name and type of return fields

### DIFF
--- a/scripts/dl.js
+++ b/scripts/dl.js
@@ -18,6 +18,6 @@ hexo.extend.tag.register('dtdd', function(args, content) {
 
   return hexo.render.render({text: content, engine: 'md'})
     .then(function(markdownContent) {
-      return '<dt>' + namespan + typespan + '</dt><dd>' + markdownContent + '</dd>';
+      return '<dt>' + namespan + ' ' + typespan + '</dt><dd>' + markdownContent + '</dd>';
     });
 }, { ends: true, async: true });


### PR DESCRIPTION
There is currently no space between the name and the type of fields in returned objects. For instance, for Connections (http://docs.meteor.com/api/connections.html):
`connectedBoolean` instead of `connected Boolean`. 

This PR fixes that.