### PR TITLE
Document new parameters for Accounts onLogout

### DIFF
--- a/source/api/accounts-multi.md
+++ b/source/api/accounts-multi.md
@@ -54,6 +54,19 @@ client, no arguments are passed.
 
 {% apibox "AccountsCommon#onLogout" %}
 
+On the server, the `func` callback receives a single argument with the object below. On the
+client, no arguments are passed.
+
+<dl class="objdesc">
+{% dtdd name:"user" type:"Object" %}
+  The Meteor user object of the user which just logged out.
+{% enddtdd %}
+
+{% dtdd name:"connection" type:"Object" %}
+  The `connection` object the request came in on. See
+  [`Meteor.onConnection`](#meteor_onconnection) for details.
+{% enddtdd %}
+</dl>
 
 {% apibox "AccountsClient" %}
 


### PR DESCRIPTION
This will be a vNEXT change and depends on meteor/meteor#7433 getting merged and shows the object which will be passed to onLogout on the server when a user logs out.