### PR TITLE
Indicate that `meteor build` can produce a directory as well.

### DIFF
--- a/source/commandline.md
+++ b/source/commandline.md
@@ -232,8 +232,9 @@ running. Quit all running meteor applications before running this.
 Package this project up for deployment. The output is a directory with several
 build artifacts:
 
-<ul><li>a tarball that includes everything necessary to run the application server
-  (see the <code>README</code> in the tarball for details)</li>
+<ul><li>a tarball (.tar.gz) that includes everything necessary to run the application
+  server (see the <code>README</code> in the tarball for details).  Using the
+  `--directory` option will produce a `bundle` directory instead of the tarball.</li>
 <li>an unsigned <code>apk</code> bundle and a project source if Android is targetted as a
   mobile platform</li>
 <li>a directory with an Xcode project source if iOS is targetted as a mobile


### PR DESCRIPTION
It should be made clear that in lieu of a tarball, the `--directory` argument can be passed to `meteor build` to produce a `bundle` directory.

Related to meteor/meteor#7587