### PR TITLE
Fixed Link to Blaze Template API Docs

### DIFF
--- a/source/api/templates.md
+++ b/source/api/templates.md
@@ -4,4 +4,4 @@ order: 11
 description: Documentation of Meteor's template API.
 ---
 
-This documentation has moved to the [Blaze Community Site](http://blazejs.org/templates.html).
+This documentation has moved to the [Blaze Community Site](http://blazejs.org/api/templates.html).


### PR DESCRIPTION
The old link was broken. I fixed it here.