### PR TITLE
Fixed Link to Blaze API Docs

### DIFF
--- a/source/api/blaze.md
+++ b/source/api/blaze.md
@@ -4,4 +4,4 @@ order: 12
 description: Documentation of how to use Blaze, Meteor's reactive rendering engine.
 ---
 
-This documentation has moved to the [Blaze Community Site](http://blazejs.org/blaze.html).
+This documentation has moved to the [Blaze Community Site](http://blazejs.org/api/blaze.html).

--- a/source/api/blaze.md
+++ b/source/api/blaze.md
@@ -4,4 +4,4 @@ order: 12
 description: Documentation of how to use Blaze, Meteor's reactive rendering engine.
 ---
 
-This documentation has moved to the [Blaze Community Site](http://blazejs.org/api/blaze.html).
+This documentation has moved to the [Blaze Community Site](http://blazejs.org/).

--- a/source/api/blaze.md
+++ b/source/api/blaze.md
@@ -4,4 +4,4 @@ order: 12
 description: Documentation of how to use Blaze, Meteor's reactive rendering engine.
 ---
 
-This documentation has moved to the [Blaze Community Site](http://blazejs.org/).
+This documentation has moved to the [Blaze Community Site](http://blazejs.org/api/blaze.html).


### PR DESCRIPTION
The old link was broken. This one works.