### PR TITLE
Link to Blaze documentation was broken after #86

### DIFF
--- a/source/api/blaze.md
+++ b/source/api/blaze.md
@@ -4,4 +4,4 @@ order: 12
 description: Documentation of how to use Blaze, Meteor's reactive rendering engine.
 ---
 
-This documentation has moved to the [Blaze Community Site](http://blazejs.org/api/blaze.html).
+This documentation has moved to the [Blaze Community Site](http://blazejs.org).


### PR DESCRIPTION
Now just pointing to the domain, that is less likely to change.