### PR TITLE
Update audit-argument-checks.md

### DIFF
--- a/source/packages/audit-argument-checks.md
+++ b/source/packages/audit-argument-checks.md
@@ -4,7 +4,7 @@ description: Documentation of Meteor's `audit-argument-checks` package.
 ---
 
 This package causes Meteor to require that all arguments passed to methods and
-publish functions are [`check`ed](#check). Any method that does not pass each
+publish functions are [checked](#check). Any method that does not pass each
 one of its arguments to `check` will throw an error, which will be logged on the
 server and which will appear to the client as a
 `500 Internal server error`. This is a simple way to help ensure that your


### PR DESCRIPTION
Without the proposed change, the documentation displays the `checked` link on the [Audit Argument Checks](https://docs.meteor.com/packages/audit-argument-checks.html) page as a single word with a style split down the middle. Half the word red, half the word green.