### PR TITLE
Include Paragraph about OPTIONS-Call on client

### DIFF
--- a/source/api/http.md
+++ b/source/api/http.md
@@ -28,6 +28,8 @@ connection to run in
 the mean time.  On the client, this function must be used
 asynchronously by passing a callback.
 
+If you use the same code on the server and the client, be aware that on the client your browser might issue an `OPTION`-call before your `POST`, `GET`, etc. call as per standard protocol to figure out Cross Origin Resource Sharing (CORS) settings.
+
 Both HTTP and HTTPS protocols are supported.  The `url` argument must be
 an absolute URL including protocol and host name on the server, but may be
 relative to the current host on the client.  The `query` option

--- a/source/api/http.md
+++ b/source/api/http.md
@@ -25,10 +25,12 @@ methods, as the method can succeed or fail based on the results of the
 synchronous HTTP call.  In this case, consider using
 [`this.unblock()`](#method_unblock) to allow other methods on the same
 connection to run in
-the mean time.  On the client, this function must be used
-asynchronously by passing a callback.
+the mean time.  
 
-If you use the same code on the server and the client, be aware that on the client your browser might issue an `OPTION`-call before your `POST`, `GET`, etc. call as per standard protocol to figure out Cross Origin Resource Sharing (CORS) settings.
+On the client, this function must be used asynchronously by passing a 
+callback. Note that some browsers first send an `OPTIONS` request before 
+sending your request (in order to [determine CORS headers]
+(http://stackoverflow.com/a/21783145/627729)).
 
 Both HTTP and HTTPS protocols are supported.  The `url` argument must be
 an absolute URL including protocol and host name on the server, but may be


### PR DESCRIPTION
As on posted on `https://forums.meteor.com/t/solved-meteor-http-client-sided-post-produces-options-call/30221/6` I improve the docs with warning about the client sided option-call if you use the same code as on the server and have a really basic rest-api where you need to implement the options-call yourself.

e.g. simplehttpserver in python has a really strange way of telling you that there is a problem as it tells you that the OPTIONS-Method is not defined. Because POST, GET, etc is also called method this mislead me into thinking that meteor does strange things here.