### PR TITLE
Add details about other options that the `accounts-*` packages support

### DIFF
--- a/source/api/accounts.md
+++ b/source/api/accounts.md
@@ -157,10 +157,13 @@ Available functions are:
 
 * `Meteor.loginWithMeteorDeveloperAccount`
 * `Meteor.loginWithFacebook`
+  * `options` may also include [Facebook's `auth_type` parameter](https://developers.facebook.com/docs/facebook-login/manually-build-a-login-flow#reaskperms)
 * `Meteor.loginWithGithub`
 * `Meteor.loginWithGoogle`
+  * `options` may also include [Google's additional URI parameters](https://developers.google.com/identity/protocols/OpenIDConnect#authenticationuriparameters)
 * `Meteor.loginWithMeetup`
 * `Meteor.loginWithTwitter`
+  * `options` may also include [Twitter's `force_login` parameter](https://dev.twitter.com/oauth/reference/get/oauth/authenticate)
 * `Meteor.loginWithWeibo`
 
 These functions initiate the login process with an external


### PR DESCRIPTION
This adds details about what options other `accounts-*` packages support:

* Google supports [many](https://developers.google.com/identity/protocols/OpenIDConnect#authenticationuriparameters)
* Facebook supports [`auth_type`](https://developers.facebook.com/docs/facebook-login/manually-build-a-login-flow#reaskperms)
* Twitter supports [`force_login`](https://dev.twitter.com/oauth/reference/get/oauth/authenticate)

These are all supported in the Meteor code too, just not documented.

Related to meteor/meteor#7584 meteor/meteor#7078 and meteor/meteor#7820