### PR TITLE
Throw error when trying to render missing `apibox` calls

### DIFF
--- a/scripts/api-box.js
+++ b/scripts/api-box.js
@@ -22,12 +22,20 @@ var DocsData = require(dataPath);
 hexo.extend.tag.register('apibox', function(args) {
   var name = args.shift();
   var options = parseTagOptions(args)
+
+  var dataFromApi = apiData({ name: name });
+
+  if (! dataFromApi) {
+    throw new Error("Cannot render apibox without API data: " + name);
+    return;
+  }
+
   var defaults = {
     // by default, nest if it's a instance method
     nested: name.indexOf('#') !== -1,
     instanceDelimiter: '#'
   };
-  var data = _.extend({}, defaults, options, apiData({ name: name }));
+  var data = _.extend({}, defaults, options, dataFromApi);
 
   data.id = data.longname.replace(/[.#]/g, "-");
 


### PR DESCRIPTION
With Meteor 1.4, the PackageAPI was decomposed into different packages in https://github.com/meteor/meteor/commit/14ee8775c3b2b0e6a90f911a68a1895110c6cf62.  This broke the existing `apibox` calls for these since they need their `@memberof` changed to `PackageNamespace` (same as was done with `PackageAPI`).

Without this change, an error was still produced by the template renderer (the same as seen in meteor/docs#56).  Unfortunately, the error didn't make it clear WHAT in particular failed, outputting at the very end withoug the specific `apidoc` call.

This commit changes the logic to throw an error for the actual missing apidoc call, which if not fixed, will cause the deployment to appear to finish but not actually generate the docs, as seen here:

https://circleci.com/gh/meteor/docs/223

This, combined with meteor/hexo-s3-deploy#2 should cause the deploy to fail properly and for a clear reason.  I barely noticed this otherwise.

/cc @tmeasday 