### PR TITLE
Update `meteor node` and `meteor npm` command line documentation.

### DIFF
--- a/source/commandline.md
+++ b/source/commandline.md
@@ -383,13 +383,13 @@ Additional parameters can be passed in the same way as the `npm` command
 full list of commands and for a better understanding of their usage.
 
 For example, executing `meteor npm install lodash --save` would install `lodash`
-from npm, to your `node_modules` directory and save its usage in your
+from npm to your `node_modules` directory and save its usage in your
 [`package.json`](https://docs.npmjs.com/files/package.json) file.
 
 Using the `meteor npm ...` commands in place of traditional `npm ...` commands
-is particularly important when using Node.js modules which have binary
-dependencies which make native C calls (like [`bcrypt`](https://www.npmjs.com/package/bcrypt))
-by ensuring that they are built using the same libaries.
+is particularly important when using Node.js modules that have binary
+dependencies that make native C calls (like [`bcrypt`](https://www.npmjs.com/package/bcrypt))
+because doing so ensures that they are built using the same libaries.
 
 Additionally, this access to the npm that comes with Meteor avoids the need to
 download and install npm separately.
@@ -397,13 +397,13 @@ download and install npm separately.
 <h2 id="meteornode">meteor node</h2>
 
 The `meteor node` command calls the
-[`node`](https://nodejs.org) command bundled with Meteor itself.
+[`node`](https://nodejs.org) version bundled with Meteor itself.
 
-> This is not to be confused with [`meteor shell`](#meteorshell) which provides
+> This is not to be confused with [`meteor shell`](#meteorshell), which provides
 an almost identical experience but also gives you access to the "server" context
 of a Meteor application.  Typically, `meteor shell` will be preferred.
 
-Additional parameters can be passed in the same way as the `node` command and
+Additional parameters can be passed in the same way as the `node` command, and
 the [Node.js documentation](https://nodejs.org/dist/latest-v4.x/docs/api/cli.html)
 should be consulted for the full list of commands and for a better understanding
 of their usage.

--- a/source/commandline.md
+++ b/source/commandline.md
@@ -373,21 +373,44 @@ commands can be accessed by pressing the up arrow.
 
 <h2 id="meteornpm">meteor npm</h2>
 
-Calling `meteor npm` calls the `npm` command bundled with meteor.
+The `meteor npm` command calls the
+[`npm`](https://docs.npmjs.com/getting-started/what-is-npm) version bundled
+with Meteor itself.
 
-Pass additional arguments as you would to `npm`.
+Additional parameters can be passed in the same way as the `npm` command
+(e.g. `meteor npm rebuild`, `meteor npm ls`, etc.) and the
+[npm documentation](https://docs.npmjs.com/) should be consulted for the
+full list of commands and for a better understanding of their usage.
 
-For example, executing `meteor npm install bootstrap` would install bootstrap
-from npm, to your `node_modules` dir.
+For example, executing `meteor npm install lodash --save` would install `lodash`
+from npm, to your `node_modules` directory and save its usage in your
+[`package.json`](https://docs.npmjs.com/files/package.json) file.
 
-This is useful for ensuring that you install dependencies with npm v3,
-as expected by meteor since [v1.3.4](https://github.com/meteor/meteor/blob/devel/History.md#v134)
+Using the `meteor npm ...` commands in place of traditional `npm ...` commands
+is particularly important when using Node.js modules which have binary
+dependencies which make native C calls (like [`bcrypt`](https://www.npmjs.com/package/bcrypt))
+by ensuring that they are built using the same libaries.
+
+Additionally, this access to the npm that comes with Meteor avoids the need to
+download and install npm separately.
 
 <h2 id="meteornode">meteor node</h2>
 
-Calling `meteor node` calls the `node` command bundled with meteor.
+The `meteor node` command calls the
+[`node`](https://nodejs.org) command bundled with Meteor itself.
 
-Pass additional arguments as you would to `node`.
+> This is not to be confused with [`meteor shell`](#meteorshell) which provides
+an almost identical experience but also gives you access to the "server" context
+of a Meteor application.  Typically, `meteor shell` will be preferred.
 
-For example, executing `meteor node -e "console.log(process.versions)"` would
+Additional parameters can be passed in the same way as the `node` command and
+the [Node.js documentation](https://nodejs.org/dist/latest-v4.x/docs/api/cli.html)
+should be consulted for the full list of commands and for a better understanding
+of their usage.
+
+For example, executing `meteor node` will enter the Node.js
+[Read-Eval-Print-Loop (REPL)](https://nodejs.org/dist/latest-v4.x/docs/api/repl.html)
+interface and allow you to interactively run JavaScript and see the results.
+
+Executing `meteor node -e "console.log(process.versions)"` would
 run `console.log(process.versions)` in the version of `node` bundled with Meteor.


### PR DESCRIPTION
This adds further details about the importance of the `meteor node` and
`meteor npm` commands.

I've added this to provide an easy place to link to from the Meteor
Tutorials (and other locations!) and was inspired to do so trying to follow up on
meteor/tutorials#68 where I couldn't help but understand the developer's confusion since it hadn't been explained earlier in the tutorial.

This PR is a requirement for meteor/tutorials#116.

Critique is appreciated (if necessary) but feel free to merge if it looks good!