### PR TITLE
Modernize examples (ECMAScript and code style)

### DIFF
--- a/source/api/accounts-multi.md
+++ b/source/api/accounts-multi.md
@@ -109,14 +109,17 @@ Example:
 
 ```js
 // Validate username, sending a specific error message on failure.
-Accounts.validateNewUser(function (user) {
-  if (user.username && user.username.length >= 3)
+Accounts.validateNewUser((user) => {
+  if (user.username && user.username.length >= 3) {
     return true;
-  throw new Meteor.Error(403, "Username must have at least 3 characters");
+  } else {
+    throw new Meteor.Error(403, 'Username must have at least 3 characters');
+  }
 });
+
 // Validate username, without a specific error message.
-Accounts.validateNewUser(function (user) {
-  return user.username !== "root";
+Accounts.validateNewUser((user) => {
+  return user.username !== 'root';
 });
 ```
 
@@ -153,16 +156,16 @@ hook. This can only be called once.
 
 Example:
 
-<!-- XXX replace d6 with _.random once we have underscore 1.4.2 -->
-
 ```js
-// Support for playing D&D: Roll 3d6 for dexterity
-Accounts.onCreateUser(function(options, user) {
-  var d6 = function () { return Math.floor(Random.fraction() * 6) + 1; };
-  user.dexterity = d6() + d6() + d6();
+// Support for playing D&D: Roll 3d6 for dexterity.
+Accounts.onCreateUser((options, user) => {
+  user.dexterity = _.random(1, 6) + _.random(1, 6) + _.random(1, 6);
+
   // We still want the default hook's 'profile' behavior.
-  if (options.profile)
+  if (options.profile) {
     user.profile = options.profile;
+  }
+
   return user;
 });
 ```
@@ -230,8 +233,9 @@ error generally have no need to run if the attempt has already been determined
 to fail, and should start with
 
 ```js
-if (!attempt.allowed)
+if (!attempt.allowed) {
   return false;
+}
 ```
 
 <h2 id="accounts_rate_limit">Rate Limiting</h2>

--- a/source/api/accounts.md
+++ b/source/api/accounts.md
@@ -43,26 +43,26 @@ user document:
 
 ```js
 {
-  _id: "bbca5d6a-2156-41c4-89da-0329e8c99a4f",  // Meteor.userId()
-  username: "cool_kid_13", // unique name
+  _id: 'QwkSmTCZiw5KDx3L6',  // Meteor.userId()
+  username: 'cool_kid_13', // Unique name
   emails: [
-    // each email address can only belong to one user.
-    { address: "cool@example.com", verified: true },
-    { address: "another@different.com", verified: false }
+    // Each email address can only belong to one user.
+    { address: 'cool@example.com', verified: true },
+    { address: 'another@different.com', verified: false }
   ],
-  createdAt: Wed Aug 21 2013 15:16:52 GMT-0700 (PDT),
+  createdAt: new Date('Wed Aug 21 2013 15:16:52 GMT-0700 (PDT)'),
   profile: {
     // The profile is writable by the user by default.
-    name: "Joe Schmoe"
+    name: 'Joe Schmoe'
   },
   services: {
     facebook: {
-      id: "709050", // facebook id
-      accessToken: "AAACCgdX7G2...AbV9AZDZD"
+      id: '709050', // Facebook ID
+      accessToken: 'AAACCgdX7G2...AbV9AZDZD'
     },
     resume: {
       loginTokens: [
-        { token: "97e8c205-c7e4-47c9-9bea-8e2ccc0694cd",
+        { token: '97e8c205-c7e4-47c9-9bea-8e2ccc0694cd',
           when: 1349761684048 }
       ]
     }
@@ -98,18 +98,19 @@ published to the client. You can publish additional fields for the
 current user with:
 
 ```js
-// server
-Meteor.publish("userData", function () {
+// Server
+Meteor.publish('userData', function () {
   if (this.userId) {
-    return Meteor.users.find({_id: this.userId},
-                             {fields: {'other': 1, 'things': 1}});
+    return Meteor.users.find({ _id: this.userId }, {
+      fields: { other: 1, things: 1 }
+    });
   } else {
     this.ready();
   }
 });
 
-// client
-Meteor.subscribe("userData");
+// Client
+Meteor.subscribe('userData');
 ```
 
 If the autopublish package is installed, information about all users
@@ -128,7 +129,7 @@ Users are by default allowed to specify their own `profile` field with
 their user document:
 
 ```js
-Meteor.users.deny({update: function () { return true; }});
+Meteor.users.deny({ update: () => true });
 ```
 
 {% apibox "Meteor.loggingIn" %}
@@ -219,12 +220,12 @@ Then, in your app:
 
 ```js
 ServiceConfiguration.configurations.upsert(
-  { service: "weibo" },
+  { service: 'weibo' },
   {
     $set: {
-      clientId: "1292962797",
-      loginStyle: "popup",
-      secret: "75a730b58f5691de5522789070c319bc"
+      clientId: '1292962797',
+      loginStyle: 'popup',
+      secret: '75a730b58f5691de5522789070c319bc'
     }
   }
 );
@@ -239,12 +240,13 @@ meteor add accounts-github
 
 and use the `Meteor.loginWithGithub` function:
 
-```javascript
+```js
 Meteor.loginWithGithub({
   requestPermissions: ['user', 'public_repo']
-}, function (err) {
-  if (err)
-    Session.set('errorMessage', err.reason || 'Unknown error');
+}, (error) => {
+  if (error) {
+    Session.set('errorMessage', error.reason || 'Unknown error');
+  }
 });
 ```
 
@@ -265,7 +267,7 @@ When configuring OAuth login with a provider (such as Facebook or Google), Meteo
 
 You can also pick which type of login to do by passing an option to [`Meteor.loginWith<ExternalService>`](#meteor_loginwithexternalservice)
 
-Usually, the popup-based flow is preferable because the user will not have to reload your whole app at the end of the login flow. However, the popup-based flow requires browser features such as `window.close` and `window.opener` that are not available in all mobile environments. In particular, we recommend using `Meteor.loginWith<ExternalService>({ loginStyle: "redirect" })` in the following environments:
+Usually, the popup-based flow is preferable because the user will not have to reload your whole app at the end of the login flow. However, the popup-based flow requires browser features such as `window.close` and `window.opener` that are not available in all mobile environments. In particular, we recommend using `Meteor.loginWith<ExternalService>({ loginStyle: 'redirect' })` in the following environments:
 
 * Inside UIWebViews (when your app is loaded inside a mobile app)
 * In Safari on iOS8 (`window.close` is not supported due to a bug)

--- a/source/api/assets.md
+++ b/source/api/assets.md
@@ -20,7 +20,7 @@ directory called `nested` with a file called `data.txt` inside it, then server
 code can read `data.txt` by running:
 
 ```js
-var data = Assets.getText('nested/data.txt');
+const data = Assets.getText('nested/data.txt');
 ```
 
 Note: Packages can only access their own assets. If you need to read the assets of a different package, or of the enclosing app, you need to get a reference to that package's `Assets` object.

--- a/source/api/check.md
+++ b/source/api/check.md
@@ -20,28 +20,30 @@ functions expect their arguments to be of a particular type. `check` is a lightw
 checking that arguments and other values are of the expected type. For example:
 
 ```js
-Meteor.publish("chats-in-room", function (roomId) {
-  // Make sure roomId is a string, not an arbitrary mongo selector object.
+Meteor.publish('chatsInRoom', function (roomId) {
+  // Make sure `roomId` is a string, not an arbitrary Mongo selector object.
   check(roomId, String);
-  return Chats.find({room: roomId});
+  return Chats.find({ room: roomId });
 });
 
-Meteor.methods({addChat: function (roomId, message) {
-  check(roomId, String);
-  check(message, {
-    text: String,
-    timestamp: Date,
-    // Optional, but if present must be an array of strings.
-    tags: Match.Maybe([String])
-  });
+Meteor.methods({
+  addChat(roomId, message) {
+    check(roomId, String);
+    check(message, {
+      text: String,
+      timestamp: Date,
+      // Optional, but if present must be an array of strings.
+      tags: Match.Maybe([String])
+    });
 
-  // ... do something with the message ...
-}});
+    // Do something with the message...
+  }
+});
 ```
 
 If the match fails, `check` throws a `Match.Error` describing how it failed. If
 this error gets sent over the wire to the client, it will appear only as
-`Meteor.Error(400, "Match Failed")`. The failure details will be written to the
+`Meteor.Error(400, 'Match Failed')`. The failure details will be written to the
 server logs but not revealed to the client.
 
 {% apibox "Match.test" %}
@@ -49,13 +51,13 @@ server logs but not revealed to the client.
 `Match.test` can be used to identify if a variable has a certain structure.
 
 ```js
-// will return true for {foo: 1, bar: "hello"} or similar
-Match.test(value, {foo: Match.Integer, bar: String});
+// Will return true for `{ foo: 1, bar: 'hello' }` or similar.
+Match.test(value, { foo: Match.Integer, bar: String });
 
-// will return true if value is a string
+// Will return true if `value` is a string.
 Match.test(value, String);
 
-// will return true if value is a String or an array of Numbers
+// Will return true if `value` is a string or an array of numbers.
 Match.test(value, Match.OneOf(String, [Number]));
 ```
 
@@ -86,7 +88,7 @@ A one-element array matches an array of elements, each of which match
 `[Match.Any]` matches any array.
 {% enddtdd %}
 
-<dt><span class="name"><code>{<em>key1</em>: <em>pattern1</em>, <em>key2</em>: <em>pattern2</em>, ...}</code></span></dt>
+<dt><span class="name"><code>{ <em>key1</em>: <em>pattern1</em>, <em>key2</em>: <em>pattern2</em>, ... }</code></span></dt>
 <dd>
 Matches an Object with the given keys, with values matching the given patterns.
 If any *pattern* is a `Match.Maybe` or `Match.Optional`, that key does not need to exist
@@ -94,7 +96,7 @@ in the object. The value may not contain any keys not listed in the pattern.
 The value must be a plain Object with no special prototype.
 </dd>
 
-<dt><span class="name"><code>Match.ObjectIncluding({<em>key1</em>: <em>pattern1</em>, <em>key2</em>: <em>pattern2</em>, ...})</code></span></dt>
+<dt><span class="name"><code>Match.ObjectIncluding({ <em>key1</em>: <em>pattern1</em>, <em>key2</em>: <em>pattern2</em>, ... })</code></span></dt>
 <dd>
 Matches an Object with the given keys; the value may also have other keys
 with arbitrary values.
@@ -116,11 +118,12 @@ wire.
 
 {% codeblock lang:js %}
 // In an object
-var pattern = { name: Match.Maybe(String) };
-check({ name: "something" }, pattern) // OK
-check({}, pattern) // OK
-check({ name: undefined }, pattern) // Throws an exception
-check({ name: null }, pattern) // Throws an exception
+const pattern = { name: Match.Maybe(String) };
+
+check({ name: 'something' }, pattern); // OK
+check({}, pattern); // OK
+check({ name: undefined }, pattern); // Throws an exception
+check({ name: null }, pattern); // Throws an exception
 
 // Outside an object
 check(null, Match.Maybe(String)); // OK
@@ -152,10 +155,11 @@ from the call to `check` or `Match.test`. Examples:
 {% codeblock lang:js %}
 check(buffer, Match.Where(EJSON.isBinary));
 
-NonEmptyString = Match.Where(function (x) {
+const NonEmptyString = Match.Where((x) => {
   check(x, String);
   return x.length > 0;
 });
+
 check(arg, NonEmptyString);
 {% endcodeblock %}
 {% enddtdd %}

--- a/source/api/collections.md
+++ b/source/api/collections.md
@@ -17,10 +17,9 @@ property whose value is unique in the collection, which Meteor will set when you
 first create the document.
 
 ```js
-// common code on client and server declares a DDP-managed mongo
-// collection.
-Chatrooms = new Mongo.Collection("chatrooms");
-Messages = new Mongo.Collection("messages");
+// Common code on client and server declares a DDP-managed Mongo collection.
+const Chatrooms = new Mongo.Collection('chatrooms');
+const Messages = new Mongo.Collection('messages');
 ```
 
 The function returns an object with methods to [`insert`](#insert)
@@ -31,14 +30,14 @@ compatible with the popular Mongo database API.  The same database API
 works on both the client and the server (see below).
 
 ```js
-// return array of my messages
-var myMessages = Messages.find({userId: Session.get('myUserId')}).fetch();
+// Return an array of my messages.
+const myMessages = Messages.find({ userId: Session.get('myUserId') }).fetch();
 
-// create a new message
-Messages.insert({text: "Hello, world!"});
+// Create a new message.
+Messages.insert({ text: 'Hello, world!' });
 
-// mark my first message as "important"
-Messages.update(myMessages[0]._id, {$set: {important: true}});
+// Mark my first message as important.
+Messages.update(myMessages[0]._id, { $set: { important: true } });
 ```
 
 If you pass a `name` when you create the collection, then you are
@@ -89,27 +88,28 @@ and instead call [`Meteor.publish`](#meteor_publish) to specify which parts of
 your collection should be published to which users.
 
 ```js
-// Create a collection called Posts and put a document in it. The
-// document will be immediately visible in the local copy of the
-// collection. It will be written to the server-side database
-// a fraction of a second later, and a fraction of a second
-// after that, it will be synchronized down to any other clients
-// that are subscribed to a query that includes it (see
-// Meteor.subscribe and autopublish)
-Posts = new Mongo.Collection("posts");
-Posts.insert({title: "Hello world", body: "First post"});
+// Create a collection called `Posts` and put a document in it. The document
+// will be immediately visible in the local copy of the collection. It will be
+// written to the server-side database a fraction of a second later, and a
+// fraction of a second after that, it will be synchronized down to any other
+// clients that are subscribed to a query that includes it (see
+// `Meteor.subscribe` and `autopublish`).
+const Posts = new Mongo.Collection('posts');
+Posts.insert({ title: 'Hello world', body: 'First post' });
 
-// Changes are visible immediately -- no waiting for a round trip to
-// the server.
+// Changes are visible immediately—no waiting for a round trip to the server.
 assert(Posts.find().count() === 1);
 
-// Create a temporary, local collection. It works just like any other
-// collection, but it doesn't send changes to the server, and it
-// can't receive any data from subscriptions.
-Scratchpad = new Mongo.Collection;
-for (var i = 0; i < 10; i++)
-  Scratchpad.insert({number: i * 2});
-assert(Scratchpad.find({number: {$lt: 9}}).count() === 5);
+// Create a temporary, local collection. It works just like any other collection
+// but it doesn't send changes to the server, and it can't receive any data from
+// subscriptions.
+const Scratchpad = new Mongo.Collection;
+
+for (let i = 0; i < 10; i += 1) {
+  Scratchpad.insert({ number: i * 2 });
+}
+
+assert(Scratchpad.find({ number: { $lt: 9 } }).count() === 5);
 ```
 
 Generally, you'll assign `Mongo.Collection` objects in your app to global
@@ -125,24 +125,25 @@ can also specify `transform` on a particular `find`, `findOne`, `allow`, or
 the value of the document's `_id` field (though it's OK to leave it out).
 
 ```js
-// An Animal class that takes a document in its constructor
-Animal = function (doc) {
-  _.extend(this, doc);
-};
-_.extend(Animal.prototype, {
-  makeNoise: function () {
+// An animal class that takes a document in its constructor.
+class Animal {
+  constructor(doc) {
+    _.extend(this, doc);
+  }
+
+  makeNoise() {
     console.log(this.sound);
   }
+}
+
+// Define a collection that uses `Animal` as its document.
+const Animals = new Mongo.Collection('animals', {
+  transform: (doc) => new Animal(doc)
 });
 
-// Define a Collection that uses Animal as its document
-Animals = new Mongo.Collection("Animals", {
-  transform: function (doc) { return new Animal(doc); }
-});
-
-// Create an Animal and call its makeNoise method
-Animals.insert({name: "raptor", sound: "roar"});
-Animals.findOne({name: "raptor"}).makeNoise(); // prints "roar"
+// Create an animal and call its `makeNoise` method.
+Animals.insert({ name: 'raptor', sound: 'roar' });
+Animals.findOne({ name: 'raptor' }).makeNoise(); // Prints 'roar'
 ```
 
 `transform` functions are not called reactively.  If you want to add a
@@ -239,9 +240,10 @@ undefined.  If the insert is successful, `error` is undefined and
 Example:
 
 ```js
-var groceriesId = Lists.insert({name: "Groceries"});
-Items.insert({list: groceriesId, name: "Watercress"});
-Items.insert({list: groceriesId, name: "Persimmons"});
+const groceriesId = Lists.insert({ name: 'Groceries' });
+
+Items.insert({ list: groceriesId, name: 'Watercress' });
+Items.insert({ list: groceriesId, name: 'Persimmons' });
 ```
 
 {% apibox "Mongo.Collection#update" %}
@@ -283,12 +285,14 @@ indicating the number of affected documents if the update was successful.
 Client example:
 
 ```js
-// When the givePoints button in the admin dashboard is pressed,
-// give 5 points to the current player. The new score will be
-// immediately visible on everyone's screens.
+// When the 'give points' button in the admin dashboard is pressed, give 5
+// points to the current player. The new score will be immediately visible on
+// everyone's screens.
 Template.adminDashboard.events({
-  'click .givePoints': function () {
-    Players.update(Session.get("currentPlayer"), {$inc: {score: 5}});
+  'click .give-points'() {
+    Players.update(Session.get('currentPlayer'), {
+      $inc: { score: 5 }
+    });
   }
 });
 ```
@@ -296,14 +300,14 @@ Template.adminDashboard.events({
 Server example:
 
 ```js
-// Give the "Winner" badge to each user with a score greater than
-// 10. If they are logged in and their badge list is visible on the
-// screen, it will update automatically as they watch.
+// Give the 'Winner' badge to each user with a score greater than 10. If they
+// are logged in and their badge list is visible on the screen, it will update
+// automatically as they watch.
 Meteor.methods({
-  declareWinners: function () {
-    Players.update({score: {$gt: 10}},
-                   {$addToSet: {badges: "Winner"}},
-                   {multi: true});
+  declareWinners() {
+    Players.update({ score: { $gt: 10 } }, {
+      $addToSet: { badges: 'Winner' }
+    }, { multi: true });
   }
 });
 ```
@@ -361,27 +365,26 @@ console.  If you provide a callback, Meteor will call that function with an
 error argument if there was an error, or a second argument indicating the number
 of removed documents if the remove was successful.
 
-Client example:
+Example (client):
 
 ```js
-// When the remove button is clicked on a chat message, delete
-// that message.
+// When the 'remove' button is clicked on a chat message, delete that message.
 Template.chat.events({
-  'click .remove': function () {
+  'click .remove'() {
     Messages.remove(this._id);
   }
 });
 ```
 
-Server example:
+Example (server):
 
 ```js
-// When the server starts, clear the log, and delete all players
-// with a karma of less than -2.
-Meteor.startup(function () {
+// When the server starts, clear the log and delete all players with a karma of
+// less than -2.
+Meteor.startup(() => {
   if (Meteor.isServer) {
     Logs.remove({});
-    Players.remove({karma: {$lt: -2}});
+    Players.remove({ karma: { $lt: -2 } });
   }
 });
 ```
@@ -428,11 +431,11 @@ proposed update.) Return `true` to permit the change.
 
 `fieldNames` is an array of the (top-level) fields in `doc` that the
 client wants to modify, for example
-`['name',`&nbsp;`'score']`.
+`['name', 'score']`.
 
 `modifier` is the raw Mongo modifier that
 the client wants to execute; for example,
-`{$set: {'name.first': "Alice"}, $inc: {score: 1}}`.
+`{ $set: { 'name.first': 'Alice' }, $inc: { score: 1 } }`.
 
 Only Mongo modifiers are supported (operations like `$set` and `$push`).
 If the user tries to replace the entire document rather than use
@@ -459,41 +462,44 @@ names to retrieve.
 Example:
 
 ```js
-// Create a collection where users can only modify documents that
-// they own. Ownership is tracked by an 'owner' field on each
-// document. All documents must be owned by the user that created
-// them and ownership can't be changed. Only a document's owner
-// is allowed to delete it, and the 'locked' attribute can be
+// Create a collection where users can only modify documents that they own.
+// Ownership is tracked by an `owner` field on each document. All documents must
+// be owned by the user that created them and ownership can't be changed. Only a
+// document's owner is allowed to delete it, and the `locked` attribute can be
 // set on a document to prevent its accidental deletion.
-
-Posts = new Mongo.Collection("posts");
+const Posts = new Mongo.Collection('posts');
 
 Posts.allow({
-  insert: function (userId, doc) {
-    // the user must be logged in, and the document must be owned by the user
-    return (userId && doc.owner === userId);
+  insert(userId, doc) {
+    // The user must be logged in and the document must be owned by the user.
+    return userId && doc.owner === userId;
   },
-  update: function (userId, doc, fields, modifier) {
-    // can only change your own documents
+
+  update(userId, doc, fields, modifier) {
+    // Can only change your own documents.
     return doc.owner === userId;
   },
-  remove: function (userId, doc) {
-    // can only remove your own documents
+
+  remove(userId, doc) {
+    // Can only remove your own documents.
     return doc.owner === userId;
   },
+
   fetch: ['owner']
 });
 
 Posts.deny({
-  update: function (userId, doc, fields, modifier) {
-    // can't change owners
+  update(userId, doc, fields, modifier) {
+    // Can't change owners.
     return _.contains(fields, 'owner');
   },
-  remove: function (userId, doc) {
-    // can't remove locked documents
+
+  remove(userId, doc) {
+    // Can't remove locked documents.
     return doc.locked;
   },
-  fetch: ['locked'] // no need to fetch 'owner'
+
+  fetch: ['locked'] // No need to fetch `owner`
 });
 ```
 
@@ -548,11 +554,12 @@ the matching documents.
 Examples:
 
 ```js
-// Print the titles of the five top-scoring posts
-var topPosts = Posts.find({}, {sort: {score: -1}, limit: 5});
-var count = 0;
-topPosts.forEach(function (post) {
-  console.log("Title of post " + count + ": " + post.title);
+// Print the titles of the five top-scoring posts.
+const topPosts = Posts.find({}, { sort: { score: -1 }, limit: 5 });
+let count = 0;
+
+topPosts.forEach((post) => {
+  console.log(`Title of post ${count}: ${post.title}`);
   count += 1;
 });
 ```
@@ -700,21 +707,23 @@ Example:
 
 ```js
 // Keep track of how many administrators are online.
-var count = 0;
-var query = Users.find({admin: true, onlineNow: true});
-var handle = query.observeChanges({
-  added: function (id, user) {
-    count++;
-    console.log(user.name + " brings the total to " + count + " admins.");
+let count = 0;
+const cursor = Users.find({ admin: true, onlineNow: true });
+
+const handle = cursor.observeChanges({
+  added(id, user) {
+    count += 1;
+    console.log(`${user.name} brings the total to ${count} admins.`);
   },
-  removed: function () {
-    count--;
-    console.log("Lost one. We're now down to " + count + " admins.");
+
+  removed() {
+    count -= 1;
+    console.log(`Lost one. We're now down to ${count} admins.`);
   }
 });
 
 // After five seconds, stop keeping the count.
-setTimeout(function () {handle.stop();}, 5000);
+setTimeout(() => handle.stop(), 5000);
 ```
 
 {% apibox "Mongo.ObjectID" %}
@@ -739,27 +748,27 @@ A slightly more complex form of selector is an object containing a set of keys
 that must match in a document:
 
 ```js
-// Matches all documents where deleted is false
-{deleted: false}
+// Matches all documents where `deleted` is false.
+{ deleted: false }
 
-// Matches all documents where the name and cognomen are as given
-{name: "Rhialto", cognomen: "the Marvelous"}
+// Matches all documents where the `name` and `cognomen` are as given.
+{ name: 'Rhialto', cognomen: 'the Marvelous' }
 
-// Matches every document
+// Matches every document.
 {}
 ```
 
 But they can also contain more complicated tests:
 
 ```js
-// Matches documents where age is greater than 18
-{age: {$gt: 18}}
+// Matches documents where `age` is greater than 18.
+{ age: { $gt: 18 } }
 
-// Also matches documents where tags is an array containing "popular"
-{tags: "popular"}
+// Matches documents where `tags` is an array containing 'popular'.
+{ tags: 'popular' }
 
-// Matches documents where fruit is one of three possibilities
-{fruit: {$in: ["peach", "plum", "pear"]}}
+// Matches documents where `fruit` is one of three possibilities.
+{ fruit: { $in: ['peach', 'plum', 'pear'] } }
 ```
 
 See the [complete
@@ -771,12 +780,12 @@ A modifier is an object that describes how to update a document in
 place by changing some of its fields. Some examples:
 
 ```js
-// Set the 'admin' property on the document to true
-{$set: {admin: true}}
+// Set the `admin` property on the document to true.
+{ $set: { admin: true } }
 
-// Add 2 to the 'votes' property, and add "Traz"
-// to the end of the 'supporters' array
-{$inc: {votes: 2}, $push: {supporters: "Traz"}}
+// Add 2 to the `votes` property and add 'Traz' to the end of the `supporters`
+// array.
+{ $inc: { votes: 2 }, $push: { supporters: 'Traz' } }
 ```
 
 But if a modifier doesn't contain any $-operators, then it is instead
@@ -784,9 +793,9 @@ interpreted as a literal document, and completely replaces whatever was
 previously in the database. (Literal document modifiers are not currently
 supported by [validated updates](#allow).)
 
-```
-// Find the document with id "123", and completely replace it.
-Users.update({_id: "123"}, {name: "Alice", friends: ["Bob"]});
+```js
+// Find the document with ID '123' and completely replace it.
+Users.update({ _id: '123' }, { name: 'Alice', friends: ['Bob'] });
 ```
 
 See the [full list of
@@ -798,19 +807,17 @@ modifiers](http://docs.mongodb.org/manual/reference/operator/update/).
 Sorts may be specified using your choice of several syntaxes:
 
 ```js
-// All of these do the same thing (sort in ascending order by
-// key "a", breaking ties in descending order of key "b")
+// All of these do the same thing (sort in ascending order by key `a`, breaking
+// ties in descending order of key `b`).
+[['a', 'asc'], ['b', 'desc']]
+['a', ['b', 'desc']]
+{ a: 1, b: -1 }
 
-[["a", "asc"], ["b", "desc"]]
-["a", ["b", "desc"]]
-{a: 1, b: -1}
+// Sorted by `createdAt` descending.
+Users.find({}, { sort: { createdAt: -1 } });
 
-// Sorted by createdAt descending
-Users.find({}, {sort: {createdAt: -1}})
-
-// Sorted by createdAt descending and by name ascending
-Users.find({}, {sort: [ ["createdAt", "desc"], ["name", "asc"] ] })
-
+// Sorted by `createdAt` descending and by `name` ascending.
+Users.find({}, { sort: [['createdAt', 'desc'], ['name', 'asc']] });
 ```
 
 The last form will only work if your JavaScript implementation
@@ -833,14 +840,14 @@ dictionary whose keys are field names and whose values are `0`. All unspecified
 fields are included.
 
 ```js
-Users.find({}, {fields: {password: 0, hash: 0}})
+Users.find({}, { fields: { password: 0, hash: 0 } });
 ```
 
 To include only specific fields in the result documents, use `1` as
 the value. The `_id` field is still included in the result.
 
 ```js
-Users.find({}, {fields: {firstname: 1, lastname: 1}})
+Users.find({}, { fields: { firstname: 1, lastname: 1 } });
 ```
 
 With one exception, it is not possible to mix inclusion and exclusion styles:
@@ -860,13 +867,16 @@ yet.
 A more advanced example:
 
 ```js
-Users.insert({ alterEgos: [{ name: "Kira", alliance: "murderer" },
-                           { name: "L", alliance: "police" }],
-               name: "Yagami Light" });
+Users.insert({
+  alterEgos: [
+    { name: 'Kira', alliance: 'murderer' },
+    { name: 'L', alliance: 'police' }
+  ],
+  name: 'Yagami Light'
+});
 
 Users.findOne({}, { fields: { 'alterEgos.name': 1, _id: 0 } });
-
-// returns { alterEgos: [{ name: "Kira" }, { name: "L" }] }
+// Returns { alterEgos: [{ name: 'Kira' }, { name: 'L' }] }
 ```
 
 See <a href="http://docs.mongodb.org/manual/tutorial/project-fields-from-query-results/#projection">

--- a/source/api/connections.md
+++ b/source/api/connections.md
@@ -91,7 +91,7 @@ connection is already closed, the callback will be called immediately.
 {% enddtdd %}
 
 {% dtdd name:"clientAddress" type:"String" %}
-  The IP address of the client in dotted form (such as `"127.0.0.1"`).
+  The IP address of the client in dotted form (such as `127.0.0.1`).
 
   If you're running your Meteor server behind a proxy (so that clients
   are connecting to the proxy instead of to your server directly),
@@ -99,7 +99,7 @@ connection is already closed, the callback will be called immediately.
   for the correct IP address to be reported by `clientAddress`.
 
   Set `HTTP_FORWARDED_COUNT` to an integer representing the number of
-  proxies in front of your server.  For example, you'd set it to `"1"`
+  proxies in front of your server.  For example, you'd set it to `1`
   when your server was behind one proxy.
 {% enddtdd %}
 

--- a/source/api/core.md
+++ b/source/api/core.md
@@ -33,9 +33,9 @@ followed by your application code.
 ```js
 // On server startup, if the database is empty, create some initial data.
 if (Meteor.isServer) {
-  Meteor.startup(function () {
+  Meteor.startup(() => {
     if (Rooms.find().count() === 0) {
-      Rooms.insert({name: "Initial room"});
+      Rooms.insert({ name: 'Initial room' });
     }
   });
 }

--- a/source/api/ejson.md
+++ b/source/api/ejson.md
@@ -17,8 +17,8 @@ and a binary buffer would be serialized in EJSON as:
 
 ```json
 {
-  "d": {"$date": 1358205756553},
-  "b": {"$binary": "c3VyZS4="}
+  "d": { "$date": 1358205756553 },
+  "b": { "$binary": "c3VyZS4=" }
 }
 ```
 
@@ -77,7 +77,7 @@ EJSON.addType('Distance', function fromJSONValue(json) {
 });
 
 EJSON.stringify(new Distance(10, 'm'));
-// "{"$type":"Distance","$value":{"value":10,"unit":"m"}}"
+// Returns '{"$type":"Distance","$value":{"value":10,"unit":"m"}}'
 ```
 
 When you add a type to EJSON, Meteor will be able to use that type in:
@@ -102,7 +102,7 @@ For example, the `toJSONValue` method for
 ```js
 function () {
   return this.toHexString();
-};
+}
 ```
 
 {% apibox "EJSON.CustomType#clone" %}

--- a/source/api/email.md
+++ b/source/api/email.md
@@ -30,28 +30,26 @@ client could send, to prevent your server from being used as a relay
 by spammers.)
 
 ```js
-// In your server code: define a method that the client can call
+// Server: Define a method that the client can call.
 Meteor.methods({
-  sendEmail: function (to, from, subject, text) {
+  sendEmail(to, from, subject, text) {
+    // Make sure that all arguments are strings.
     check([to, from, subject, text], [String]);
 
-    // Let other method calls from the same client start running,
-    // without waiting for the email sending to complete.
+    // Let other method calls from the same client start running, without
+    // waiting for the email sending to complete.
     this.unblock();
 
-    Email.send({
-      to: to,
-      from: from,
-      subject: subject,
-      text: text
-    });
+    Email.send({ to, from, subject, text });
   }
 });
 
-// In your client code: asynchronously send an email
-Meteor.call('sendEmail',
-            'alice@example.com',
-            'bob@example.com',
-            'Hello from Meteor!',
-            'This is a test of Email.send.');
+// Client: Asynchronously send an email.
+Meteor.call(
+  'sendEmail',
+  'alice@example.com',
+  'bob@example.com',
+  'Hello from Meteor!',
+  'This is a test of Email.send.'
+);
 ```

--- a/source/api/http.md
+++ b/source/api/http.md
@@ -37,8 +37,8 @@ an absolute URL including protocol and host name on the server, but may be
 relative to the current host on the client.  The `query` option
 replaces the query string of `url`.  Parameters specified in `params`
 that are put in the URL are appended to any query string.
-For example, with a `url` of `"/path?query"` and
-`params` of `{foo:"bar"}`, the final URL will be `"/path?query&foo=bar"`.
+For example, with a `url` of `'/path?query'` and
+`params` of `{ foo: 'bar' }`, the final URL will be `'/path?query&foo=bar'`.
 
 The `params` are put in the URL or the request body, depending on the
 type of request.  In the case of request with no bodies, like GET and
@@ -82,30 +82,35 @@ Contents of the result object:
 Example server method:
 
 ```js
-Meteor.methods({checkTwitter: function (userId) {
-  check(userId, String);
-  this.unblock();
-  try {
-    var result = HTTP.call("GET", "http://api.twitter.com/xyz",
-                           {params: {user: userId}});
-    return true;
-  } catch (e) {
-    // Got a network error, time-out or HTTP error in the 400 or 500 range.
-    return false;
+Meteor.methods({
+  checkTwitter(userId) {
+    check(userId, String);
+    this.unblock();
+
+    try {
+      const result = HTTP.call('GET', 'http://api.twitter.com/xyz', {
+        params: { user: userId }
+      });
+
+      return true;
+    } catch (e) {
+      // Got a network error, timeout, or HTTP error in the 400 or 500 range.
+      return false;
+    }
   }
-}});
+});
 ```
 
 Example asynchronous HTTP call:
 
 ```js
-HTTP.call("POST", "http://api.twitter.com/xyz",
-          {data: {some: "json", stuff: 1}},
-          function (error, result) {
-            if (!error) {
-              Session.set("twizzled", true);
-            }
-          });
+HTTP.call('POST', 'http://api.twitter.com/xyz', {
+  data: { some: 'json', stuff: 1 }
+}, () => (error, result) {
+  if (!error) {
+    Session.set('twizzled', true);
+  }
+});
 ```
 
 {% apibox "HTTP.get" %}

--- a/source/api/methods.md
+++ b/source/api/methods.md
@@ -11,22 +11,22 @@ Example:
 
 ```js
 Meteor.methods({
-  foo: function (arg1, arg2) {
+  foo(arg1, arg2) {
     check(arg1, String);
     check(arg2, [Number]);
 
-    // .. do stuff ..
+    // Do stuff...
 
     if (/* you want to throw an error */) {
-      throw new Meteor.Error("pants-not-found", "Can't find my pants");
+      throw new Meteor.Error('pants-not-found', "Can't find my pants");
     }
 
-    return "some return value";
+    return 'some return value';
   },
 
-  bar: function () {
-    // .. do other stuff ..
-    return "baz";
+  bar() {
+    // Do other stuff...
+    return 'baz';
   }
 });
 ```
@@ -139,10 +139,12 @@ will not throw an exception.  When the method is complete (which may or
 may not happen before `Meteor.call` returns), the callback will be
 called with two arguments: `error` and `result`. If an error was thrown,
 then `error` will be the exception object.  Otherwise, `error` will be
-undefined and the return value (possibly undefined) will be in `result`.
+`undefined` and the return value (possibly `undefined`) will be in `result`.
 
-    // async call
-    Meteor.call('foo', 1, 2, function (error, result) { ... } );
+```js
+// Asynchronous call
+Meteor.call('foo', 1, 2, (error, result) => { ... });
+```
 
 If you do not pass a callback on the server, the method invocation will
 block until the method is complete.  It will eventually return the
@@ -150,8 +152,10 @@ return value of the method, or it will throw an exception if the method
 threw an exception. (Possibly mapped to 500 Server Error if the
 exception happened remotely and it was not a `Meteor.Error` exception.)
 
-    // sync call
-    var result = Meteor.call('foo', 1, 2);
+```js
+// Synchronous call
+const result = Meteor.call('foo', 1, 2);
+```
 
 On the client, if you do not pass a callback and you are not inside a
 stub, `call` will return `undefined`, and you will have no way to get
@@ -212,15 +216,18 @@ interval.
 
 
 Here's example of defining a rule and adding it into the `DDPRateLimiter`:
-```javascript
-// Define a rule that matches login attempts by non-admin users
-var loginRule = {
-  userId: function (userId) {
-    return Meteor.users.findOne(userId).type !== 'Admin';
+```js
+// Define a rule that matches login attempts by non-admin users.
+const loginRule = {
+  userId(userId) {
+    const user = Meteor.users.findOne(userId);
+    return user && user.type !== 'admin';
   },
+
   type: 'method',
   name: 'login'
-}
+};
+
 // Add the rule, allowing up to 5 messages every 1000 milliseconds.
 DDPRateLimiter.addRule(loginRule, 5, 1000);
 ```

--- a/source/api/mobile-config.md
+++ b/source/api/mobile-config.md
@@ -13,8 +13,7 @@ The code snippet below is an example `mobile-config.js` file. The rest of this
 section will explain the specific API commands in greater detail.
 
 ```js
-// This section sets up some basic app metadata,
-// the entire section is optional.
+// This section sets up some basic app metadata, the entire section is optional.
 App.info({
   id: 'com.example.matt.uber',
   name: 'über',
@@ -28,30 +27,29 @@ App.info({
 App.icons({
   'iphone': 'icons/icon-60.png',
   'iphone_2x': 'icons/icon-60@2x.png',
-  // ... more screen sizes and platforms ...
+  // More screen sizes and platforms...
 });
 
 App.launchScreens({
   'iphone': 'splash/Default~iphone.png',
   'iphone_2x': 'splash/Default@2x~iphone.png',
-  // ... more screen sizes and platforms ...
+  // More screen sizes and platforms...
 });
 
-// Set PhoneGap/Cordova preferences
+// Set PhoneGap/Cordova preferences.
 App.setPreference('BackgroundColor', '0xff0000ff');
 App.setPreference('HideKeyboardFormAccessoryBar', true);
 App.setPreference('Orientation', 'default');
 App.setPreference('Orientation', 'all', 'ios');
 
-// Pass preferences for a particular PhoneGap/Cordova plugin
+// Pass preferences for a particular PhoneGap/Cordova plugin.
 App.configurePlugin('com.phonegap.plugins.facebookconnect', {
   APP_ID: '1234567890',
   API_KEY: 'supersecretapikey'
 });
 
-// Add custom tags for a particular PhoneGap/Cordova plugin
-// to the end of generated config.xml.
-// Universal Links is shown as an example here.
+// Add custom tags for a particular PhoneGap/Cordova plugin to the end of the
+// generated config.xml. 'Universal Links' is shown as an example here.
 App.appendToConfig(`
   <universal-links>
     <host name="localhost:3000" />
@@ -65,14 +63,14 @@ App.appendToConfig(`
 
 For example this Cordova whitelist syntax:
 
-```
+```xml
 <access origin="https://www.google-analytics.com" />
 <allow-navigation href="https://example.com" />
 ```
 
 is equivalent to:
 
-```
+```js
 App.accessRule('https://www.google-analytics.com');
 App.accessRule('https://example.com', 'navigation');
 ```

--- a/source/api/packagejs.md
+++ b/source/api/packagejs.md
@@ -12,54 +12,54 @@ The `package.js` file below is an example of how to use the packaging API. The
 rest of this section will explain the specific API commands in greater detail.
 
 ```js
-/* Information about this package */
+// Information about this package:
 Package.describe({
-  // Short two-sentence summary.
-  summary: "What this does",
-  // Version number.
-  version: "1.0.0",
-  // Optional.  Default is package directory name.
-  name: "username:package-name",
-  // Optional github URL to your source repository.
-  git: "https://github.com/something/something.git",
+  // Short two-sentence summary
+  summary: 'What this does',
+  // Version number
+  version: '1.0.0',
+  // Optional, default is package directory name
+  name: 'username:package-name',
+  // Optional GitHub URL to your source repository
+  git: 'https://github.com/something/something.git'
 });
 
-/* This defines your actual package */
-Package.onUse(function (api) {
-  // If no version is specified for an 'api.use' dependency, use the
-  // one defined in Meteor 0.9.0.
-  api.versionsFrom('0.9.0');
-  // Use Underscore package, but only on the server.
-  // Version not specified, so it will be as of Meteor 0.9.0.
+// This defines your actual package:
+Package.onUse((api) => {
+  // If no version is specified for an `api.use` dependency, use the one defined
+  // in Meteor 1.4.3.1.
+  api.versionsFrom('1.4.3.1');
+  // Use the `underscore` package, but only on the server. Version not
+  // specified, so it will be as of Meteor 1.4.3.1.
   api.use('underscore', 'server');
-  // Use kadira:flow-router, version 1.0.0 or newer.
+  // Use `kadira:flow-router`, version 2.12.1 or newer.
   api.use('kadira:flow-router@2.12.1');
-  // Give users of this package access to active-route's Javascript helpers
+  // Give users of this package access to active-route's JavaScript helpers.
   api.imply('zimme:active-route@2.3.2')
-  // Export the object 'Email' to packages or apps that use this package.
+  // Export the object `Email` to packages or apps that use this package.
   api.export('Email', 'server');
   // Specify the source code for the package.
   api.addFiles('email.js', 'server');
-
-  // When using ecmascript or modules packages, you can use this instead of
-  // api.export and api.addFiles:
+  // When using `ecmascript` or `modules` packages, you can use this instead of
+  // `api.export` and `api.addFiles`.
   api.mainModule('email.js', 'server');
 });
 
-/* This defines the tests for the package */
-Package.onTest(function (api) {
-  // Sets up a dependency on this package
+// This defines the tests for the package:
+Package.onTest((api) => {
+  // Sets up a dependency on this package.
   api.use('username:package-name');
-  // Allows you to use the mocha test framework
+  // Use the Mocha test framework.
   api.use('practicalmeteor:mocha@2.4.5_2');
-  // Specify the source code for the package tests
+  // Specify the source code for the package tests.
   api.addFiles('email_tests.js', 'server');
 });
 
-/* This lets you use npm packages in your package */
+// This lets you use npm packages in your package:
 Npm.depends({
-  simplesmtp: "0.3.10",
-  "stream-buffers": "0.2.5"});
+  simplesmtp: '0.3.10',
+  'stream-buffers': '0.2.5'
+});
 ```
 
 `api.mainModule` is documented in the [modules](http://docs.meteor.com/packages/modules.html#Modular-package-structure) section.
@@ -131,7 +131,7 @@ performs on the application and packages source:
 1. Gather source files from the app folder or read `package.js` file for a
   package.
 2. Lint all source files and print the linting warnings.
-3. Compile the source files like CoffeeScript, ES6, Less or Templates to plain
+3. Compile the source files like CoffeeScript, ES2015, Less, or Templates to plain
   JavaScript and CSS.
 4. Link the JavaScript files: wrap them into closures and provide necessary
   package imports.
@@ -164,21 +164,18 @@ examples of linters are [JSHint](http://jshint.com/about/) and
 To register a linter build plugin in your package, you need to do a couple of
 things in your `package.js`:
 - depend on the `isobuild:linter-plugin@1.0.0` package
-- register a build plugin: `Package.registerBuildPlugin({name, sources, ... });`
+- register a build plugin: `Package.registerBuildPlugin({ name, sources, ... });`
   (see [docs](http://docs.meteor.com/#/full/Package-registerBuildPlugin))
 
 In your build plugin sources, register a Linter Plugin: provide details such as
 a name, list of extensions and filenames the plugin will handle and a factory
-function that returns an instance of a linter class. Ex.:
+function that returns an instance of a linter class. Example:
 
-```javascript
+```js
 Plugin.registerLinter({
-  extensions: ["js"],
-  filenames: [".linterrc"]
-}, function () {
-  var linter = new MyLinter();
-  return linter;
-});
+  extensions: ['js'],
+  filenames: ['.linterrc']
+}, () => new MyLinter);
 ```
 
 In this example, we register a linter that runs on all `js` files and also reads
@@ -188,23 +185,20 @@ The `MyLinter` class should now implement the `processFilesForPackage`
 method. The method should accept two arguments: a list of files and an options
 object.
 
-```javascript
-function MyLinter() {}
-MyLinter.prototype.processFilesForPackage = function (files, options) {
-  var globals = options.globals;
+```js
+class MyLinter {
+  processFilesForPackage(files, options) {
+    files.forEach((file) => {
+      // Lint the file.
+      const lint = lintFile(file.getContentsAsString());
 
-  files.forEach(function (file) {
-    // lint the file
-    var lint = lintFile(file.getContentsAsString());
-    if (lint) {
-      // if there are linting errors, output them
-      file.error({
-        message: lint.text,
-        column: lint.column,
-        line: lint.line
-      });
-    }
-  });
+      if (lint) {
+        // If there are linting errors, output them.
+        const { message, line, column } = lint;
+        file.error({ message, line, column });
+      }
+    });
+  }
 }
 ```
 
@@ -221,40 +215,42 @@ See an example of a linting plugin implemented in Core: [jshint](https://github.
 Compilers are programs that take the source files and output JavaScript or
 CSS. They also can output parts of HTML that is added to the `<head>` tag and
 static assets. Examples for the compiler plugins are: CoffeeScript, Babel.js,
-JSX compilers, Jade templating compiler and others.
+JSX compilers, Pug templating compiler and others.
 
 To register a compiler plugin in your package, you need to do the following in
 your `package.js` file:
 - depend on the `isobuild:compiler-plugin@1.0.0` package
-- register a build plugin: `Package.registerBuildPlugin({name, sources, ... });`
+- register a build plugin: `Package.registerBuildPlugin({ name, sources, ... });`
   (see [docs](http://docs.meteor.com/#/full/Package-registerBuildPlugin))
 
 In your build plugin source, register a Compiler Plugin: similar to other types
 of build plugins, provide the details, extensions and filenames and a factory
 function that returns an instance of the compiler. Ex.:
 
-```javascript
+```js
 Plugin.registerCompiler({
-  extensions: ["jade", "tpl.jade"],
+  extensions: ['pug', 'tpl.pug'],
   filenames: []
-}, function () {
-  var compiler  = new JadeCompiler();
-  return compiler;
-});
+}, () => new PugCompiler);
 ```
 
 The compiler class must implement the `processFilesForTarget` method that is
 given the source files for a target (server or client part of the package/app).
 
-```javascript
-function JadeCompiler() {}
-JadeCompiler.prototype.processFilesForTarget = function (files) {
-  files.forEach(function (file) {
-    // process and add the output
-    var output = compileJade(file.getContentsAsString());
-    file.addJavaScript({ data: output, path: file.getPathInPackage() + '.js' });
-  });
-};
+```js
+class PugCompiler {
+  processFilesForTarget(files) {
+    files.forEach((file) => {
+      // Process and add the output.
+      const output = compilePug(file.getContentsAsString());
+
+      file.addJavaScript({
+        data: output,
+        path: `${file.getPathInPackage()}.js`
+      });
+    });
+  }
+}
 ```
 
 Besides the common methods available on the input files' class, the following
@@ -284,8 +280,8 @@ Meteor implements a couple of compilers as Core packages, good examples would be
 the
 [Blaze templating](https://github.com/meteor/meteor/tree/devel/packages/templating)
 package and the
-[EcmaScript](https://github.com/meteor/meteor/tree/devel/packages/ecmascript)
-package (compiles ES6/7 to JavaScript that can run in the browsers).
+[ecmascript](https://github.com/meteor/meteor/tree/devel/packages/ecmascript)
+package (compiles ES2015+ to JavaScript that can run in the browsers).
 
 <h3 id="build-plugin-minifiers">Minifiers</h3>
 
@@ -300,51 +296,49 @@ There are two types of minifiers one can add: a minifier processing JavaScript
 To register a minifier plugin in your package, add the following in your
 `package.js` file:
 - depend on `isobuild:minifier-plugin@1.0.0` package
-- register a build plugin: `Package.registerBuildPlugin({name, sources, ... });`
+- register a build plugin: `Package.registerBuildPlugin({ name, sources, ... });`
   (see [docs](http://docs.meteor.com/#/full/Package-registerBuildPlugin))
 
 In your build plugin source, register a Minifier Plugin. Similar to Linter and
 Compiler plugin, specify the interested extensions (`css` or `js`). The factory
 function returns an instance of the minifier class.
 
-```javascript
+```js
 Plugin.registerMinifier({
-  extensions: ["js"],
-  filenames: []
-}, function () {
-  var minifier  = new UglifyJsMinifier();
-  return minifier;
-});
+  extensions: ['js']
+}, () => new UglifyJsMinifier);
 ```
 
 The minifier class must implement the method `processFilesForBundle`. The first
 argument is a list of processed files and the options object specifies if the
 minifier is ran in production mode or development mode.
 
-```javascript
-function UglifyJsMinifier() {}
-UglifyJsMinifier.prototype.processFileForBundle = function (files, options) {
-var minifyMode = options.minifiyMode;
-  if (minifyMode === 'development') {
-    // don't minify in development
-    files.forEach(function (file) {
+```js
+class UglifyJsMinifier {
+  processFilesForBundle(files, options) {
+    const { minifyMode } = options;
+
+    if (minifyMode === 'development') {
+      // Don't minify in development.
+      file.forEach((file) => {
+        file.addJavaScript({
+          data: file.getContentsAsBuffer(),
+          sourceMap: file.getSourceMap(),
+          path: file.getPathInBundle()
+        });
+      });
+
+      return;
+    }
+
+    // Minify in production.
+    files.forEach((file) => {
       file.addJavaScript({
-        data: file.getContentsAsBuffer(),
-        sourceMap: file.getSourceMap(),
+        data: uglifyjs.minify(file.getContentsAsBuffer()),
         path: file.getPathInBundle()
       });
     });
-
-    return;
   }
-
-  // in production mode minifiy:
-  files.forEach(function (file) {
-    file.addJavaScript({
-      data: uglifyjs.minify(file.getContentsAsBuffer()),
-      path: file.getPathInBundle()
-    });
-  });
 }
 ```
 
@@ -352,10 +346,10 @@ In this example, we re-add the same files in the development mode to avoid
 unnecessary work and then we minify the files in production mode.
 
 Besides the common input files' methods, these methods are available:
-- getPathInBundle - returns a path of the processed file in the bundle.
-- getSourceMap - returns the source-map for the processed file if there is such.
-- addJavaScript - same as compilers
-- addStylesheet - same as compilers
+- `getPathInBundle` - returns a path of the processed file in the bundle.
+- `getSourceMap` - returns the source-map for the processed file if there is such.
+- `addJavaScript` - same as compilers
+- `addStylesheet` - same as compilers
 
 Right now, Meteor Core ships with the `standard-minifiers` package that can be
 replaced with a custom one. The
@@ -372,11 +366,11 @@ For the fast rebuilds between the Isobuild process runs, plugins can implement o
 
 There is a core package called `caching-compiler` that implements most of the common logic of keeping both in-memory and on-disk caches. The easiest way to implement caching correctly is to subclass the `CachingCompiler` or `MultiFileCachingCompiler` class from this package in your build plugin. `CachingCompiler` is for compilers that consider each file completely independently; `MultiFileCachingCompiler` is for compilers that allow files to reference each other. To get this class in your plugin namespace, add a dependency to the plugin definition:
 
-```javascript
+```js
 Package.registerBuildPlugin({
-  name: "compileGG",
-  use: [ 'caching-compiler@1.0.0' ],
-  sources: [ 'plugin/compile-gg.js' ]
+  name: 'compileGG',
+  use: ['caching-compiler@1.0.0'],
+  sources: ['plugin/compile-gg.js']
 });
 ```
 <h3 id="build-plugin-file-system">Accessing File System</h3>
@@ -391,18 +385,17 @@ Also `Plugin` provides helper functions `convertToStandardPath` and `convertToOS
 
 Example:
 
-```javascript
-// on Windows
-var fs = Plugin.fs;
-var path = Plugin.path;
+```js
+// On Windows
+const fs = Plugin.fs;
+const path = Plugin.path;
 
-var filepath = path.join('/C/Program Files', 'Program/file.txt');
+const filePath = path.join('/C/Program Files', 'Program/file.txt');
+console.log(filePath); // Prints '/C/Program Files/Program/file.txt'
 
-console.log(filepath); // prints "/C/Program Files/Program/file.txt"
+fs.writeFileSync(filePath, 'Hello.'); // Writes to 'C:\Program Files\Program\file.txt'
 
-fs.writeFileSync(filepath, "Hello."); // writes to C:\Program Files\Program\file.txt
-
-console.log(Plugin.convertToOsPath(filepath)); // prints "C:\Program Files\Program\file.txt"
+console.log(Plugin.convertToOsPath(filePath)); // Prints 'C:\Program Files\Program\file.txt'
 ```
 
 <h2 id="isobuild-features">Isobuild Feature Packages</h2>

--- a/source/api/passwords.md
+++ b/source/api/passwords.md
@@ -152,18 +152,22 @@ Override fields of the object by assigning to them:
 Example:
 
 ```js
-Accounts.emailTemplates.siteName = "AwesomeSite";
-Accounts.emailTemplates.from = "AwesomeSite Admin <accounts@example.com>";
-Accounts.emailTemplates.enrollAccount.subject = function (user) {
-    return "Welcome to Awesome Town, " + user.profile.name;
+Accounts.emailTemplates.siteName = 'AwesomeSite';
+Accounts.emailTemplates.from = 'AwesomeSite Admin <accounts@example.com>';
+
+Accounts.emailTemplates.enrollAccount.subject = (user) => {
+  return `Welcome to Awesome Town, ${user.profile.name}`;
 };
-Accounts.emailTemplates.enrollAccount.text = function (user, url) {
-   return "You have been selected to participate in building a better future!"
-     + " To activate your account, simply click the link below:\n\n"
-     + url;
+
+Accounts.emailTemplates.enrollAccount.text = (user, url) => {
+  return 'You have been selected to participate in building a better future!'
+    + ' To activate your account, simply click the link below:\n\n'
+    + url;
 };
-Accounts.emailTemplates.resetPassword.from = function () {
-   // Overrides value set in Accounts.emailTemplates.from when resetting passwords
-   return "AwesomeSite Password Reset <no-reply@example.com>";
+
+Accounts.emailTemplates.resetPassword.from = () => {
+  // Overrides the value set in `Accounts.emailTemplates.from` when resetting
+  // passwords.
+  return 'AwesomeSite Password Reset <no-reply@example.com>';
 };
 ```

--- a/source/api/reactive-var.md
+++ b/source/api/reactive-var.md
@@ -18,7 +18,7 @@ usual contract for reactive data sources.
 
 A ReactiveVar is similar to a Session variable, with a few differences:
 
-* ReactiveVars don't have global names, like the "foo" in `Session.get("foo")`.
+* ReactiveVars don't have global names, like the "foo" in `Session.get('foo')`.
   Instead, they may be created and used locally, for example attached to a
   template instance, as in: `this.foo.get()`.
 

--- a/source/api/session.md
+++ b/source/api/session.md
@@ -95,7 +95,7 @@ Example:
       rendered differently. }}
 
   {{#each posts}}
-    {{> postItem }}
+    {{> postItem}}
   {{/each}}
 </template>
 

--- a/source/api/session.md
+++ b/source/api/session.md
@@ -8,9 +8,9 @@ store an arbitrary set of key-value pairs. Use it to store things like
 the currently selected item in a list.
 
 What's special about `Session` is that it's reactive. If
-you call [`Session.get`](#session_get)`("currentList")`
+you call [`Session.get`](#session_get)`('currentList')`
 from inside a template, the template will automatically be rerendered
-whenever [`Session.set`](#session_set)`("currentList", x)` is called.
+whenever [`Session.set`](#session_set)`('currentList', x)` is called.
 
 To add `Session` to your application, run this command in your terminal:
 
@@ -23,13 +23,13 @@ meteor add session
 Example:
 
 ```js
-Tracker.autorun(function () {
-  Meteor.subscribe("chat-history", {room: Session.get("currentRoomId")});
+Tracker.autorun(() => {
+  Meteor.subscribe('chatHistory', { room: Session.get('currentRoomId') });
 });
 
-// Causes the function passed to Tracker.autorun to be re-run, so
-// that the chat-history subscription is moved to the room "home".
-Session.set("currentRoomId", "home");
+// Causes the function passed to `Tracker.autorun` to be rerun, so that the
+// 'chatHistory' subscription is moved to the room 'home'.
+Session.set('currentRoomId', 'home');
 ```
 
 `Session.set` can also be called with an object of keys and values, which is
@@ -37,8 +37,8 @@ equivalent to calling `Session.set` individually on each key/value pair.
 
 ```js
 Session.set({
-  a: "foo",
-  b: "bar"
+  a: 'foo',
+  b: 'bar'
 });
 ```
 
@@ -52,24 +52,24 @@ variable every time a new version of your app is loaded.
 Example:
 
 ```html
-<!-- in main.html -->
+<!-- main.html -->
 <template name="main">
   <p>We've always been at war with {{theEnemy}}.</p>
 </template>
 ```
 
 ```js
-// in main.js
+// main.js
 Template.main.helpers({
-  theEnemy: function () {
-    return Session.get("enemy");
+  theEnemy() {
+    return Session.get('enemy');
   }
 });
 
-Session.set("enemy", "Eastasia");
+Session.set('enemy', 'Eastasia');
 // Page will say "We've always been at war with Eastasia"
 
-Session.set("enemy", "Eurasia");
+Session.set('enemy', 'Eurasia');
 // Page will change to say "We've always been at war with Eurasia"
 ```
 
@@ -78,23 +78,25 @@ Session.set("enemy", "Eurasia");
 
 If value is a scalar, then these two expressions do the same thing:
 
-    (1) Session.get("key") === value
-    (2) Session.equals("key", value)
+```js
+Session.get('key') === value
+Session.equals('key', value)
+```
 
-... but the second one is always better. It triggers fewer invalidations
+...but the second one is always better. It triggers fewer invalidations
 (template redraws), making your program more efficient.
 
 Example:
 
 ```html
 <template name="postsView">
-{{! Show a dynamically updating list of items. Let the user click on an
-    item to select it. The selected item is given a CSS class so it
-    can be rendered differently. }}
+  {{! Show a dynamically updating list of items. Let the user click on an item
+      to select it. The selected item is given a CSS class, so it can be
+      rendered differently. }}
 
-{{#each posts}}
-  {{> postItem }}
-{{/each}}
+  {{#each posts}}
+    {{> postItem }}
+  {{/each}}
 </template>
 
 <template name="postItem">
@@ -103,23 +105,23 @@ Example:
 ```
 
 ```js
-// in JS file
 Template.postsView.helpers({
-  posts: function() {
+  posts() {
     return Posts.find();
   }
 });
 
 Template.postItem.helpers({
-  postClass: function() {
-    return Session.equals("selectedPost", this._id) ?
-      "selected" : "";
+  postClass() {
+    return Session.equals('selectedPost', this._id)
+      ? 'selected'
+      : '';
   }
 });
 
 Template.postItem.events({
-  'click': function() {
-    Session.set("selectedPost", this._id);
+  'click'() {
+    Session.set('selectedPost', this._id);
   }
 });
 ```

--- a/source/api/tracker.md
+++ b/source/api/tracker.md
@@ -32,12 +32,14 @@ For example, you can monitor a cursor (which is a reactive data
 source) and aggregate it into a session variable:
 
 ```js
-Tracker.autorun(function () {
-  var oldest = _.max(Monkeys.find().fetch(), function (monkey) {
+Tracker.autorun(() => {
+  const oldest = _.max(Monkeys.find().fetch(), (monkey) => {
     return monkey.age;
   });
-  if (oldest)
-    Session.set("oldest", oldest.name);
+
+  if (oldest) {
+    Session.set('oldest', oldest.name);
+  }
 });
 ```
 
@@ -46,12 +48,13 @@ something the first time it does, calling `stop` on the computation to
 prevent further rerunning:
 
 ```js
-Tracker.autorun(function (c) {
-  if (! Session.equals("shouldAlert", true))
+Tracker.autorun((computation) => {
+  if (!Session.equals('shouldAlert', true)) {
     return;
+  }
 
-  c.stop();
-  alert("Oh no!");
+  computation.stop();
+  alert('Oh no!');
 });
 ```
 
@@ -177,11 +180,10 @@ of calling callbacks, but ensures that it will never be rerun.
 Example:
 
 ```js
-// if we're in a computation, then perform some clean-up
-// when the current computation is invalidated (rerun or
-// stopped)
+// If we're in a computation, then perform some clean-up when the current
+// computation is invalidated (rerun or stopped).
 if (Tracker.active) {
-  Tracker.onInvalidate(function () {
+  Tracker.onInvalidate(() => {
     x.destroy();
     y.finalize();
   });
@@ -258,20 +260,21 @@ accompanied by a Dependency object that tracks the computations that depend
 on it, as in this example:
 
 ```js
-var weather = "sunny";
-var weatherDep = new Tracker.Dependency;
+let weather = 'sunny';
+const weatherDep = new Tracker.Dependency;
 
-var getWeather = function () {
-  weatherDep.depend()
+function getWeather() {
+  weatherDep.depend();
   return weather;
-};
+}
 
-var setWeather = function (w) {
-  weather = w;
-  // (could add logic here to only call changed()
-  // if the new value is different from the old)
+function setWeather(newWeather) {
+  weather = newWeather;
+
+  // Note: We could add logic here to only call `changed` if the new value is
+  // different from the old value.
   weatherDep.changed();
-};
+}
 ```
 
 This example implements a weather data source with a simple getter and
@@ -287,9 +290,9 @@ query, while another might represent just the number of documents in
 the result.  A Dependency could represent whether the weather is sunny
 or not, or whether the temperature is above freezing.
 [`Session.equals`](#session_equals) is implemented this way for
-efficiency.  When you call `Session.equals("weather", "sunny")`, the
+efficiency.  When you call `Session.equals('weather', 'sunny')`, the
 current computation is made to depend on an internal Dependency that
-does not change if the weather goes from, say, "rainy" to "cloudy".
+does not change if the weather goes from, say, `rainy` to `cloudy`.
 
 Conceptually, the only two things a Dependency can do are gain a
 dependent and change.

--- a/source/packages/appcache.md
+++ b/source/packages/appcache.md
@@ -55,7 +55,7 @@ If you have files too large to fit in the cache you can disable
 caching by URL prefix.  For example,
 
 ```js
-Meteor.AppCache.config({onlineOnly: ['/online/']});
+Meteor.AppCache.config({ onlineOnly: ['/online/'] });
 ```
 
 causes files in your `public/online` directory to not be cached, and

--- a/source/packages/ecmascript.md
+++ b/source/packages/ecmascript.md
@@ -32,7 +32,7 @@ statement `api.use('ecmascript');` in the `Package.onUse` callback in your
 `package.js` file:
 
 ```js
-Package.onUse(function (api) {
+Package.onUse((api) => {
   api.use('ecmascript');
 });
 ```
@@ -70,7 +70,7 @@ Here is a list of the Babel transformers that are currently enabled:
   Enables multi-line strings delimited by backticks instead of quotation
   marks, with variable interpolation:
   ```js
-  var name = "Ben";
+  var name = 'Ben';
   var message = `My name is:
   ${name}`;
   ```
@@ -101,7 +101,7 @@ Here is a list of the Babel transformers that are currently enabled:
   const GOLDEN_RATIO = (1 + Math.sqrt(5)) / 2;
 
   // This reassignment will be forbidden by the compiler:
-  GOLDEN_RATIO = "new value";
+  GOLDEN_RATIO = 'new value';
   ```
 
 * [`es6.blockScoping`](http://babeljs.io/docs/learn-es2015/#let-const)<br>
@@ -144,16 +144,16 @@ Here is a list of the Babel transformers that are currently enabled:
   ```js
   var counter = 0;
   function getKeyName() {
-    return "key" + counter++;
+    return 'key' + counter++;
   }
 
   var obj = {
-    [getKeyName()]: "zero",
-    [getKeyName()]: "one",
+    [getKeyName()]: 'zero',
+    [getKeyName()]: 'one',
   };
 
-  obj.key0; // "zero"
-  obj.key1; // "one"
+  obj.key0; // 'zero'
+  obj.key1; // 'one'
   ```
 
 * [`es6.parameters`](http://babeljs.io/docs/learn-es2015/#default-rest-spread)<br>
@@ -176,7 +176,7 @@ Here is a list of the Babel transformers that are currently enabled:
   `Function.prototype.apply`:
   ```js
   add(1, ...[2, 3, 4], 5); // 15
-  new Node("name", ...children);
+  new Node('name', ...children);
   [1, ...[2, 3, 4], 5]; // [1, 2, 3, 4, 5]
   ```
 
@@ -212,10 +212,10 @@ Here is a list of the Babel transformers that are currently enabled:
   function run({ command, args, callback }) { ... }
 
   run({
-    command: "git",
-    args: ["status", "."],
+    command: 'git',
+    args: ['status', '.'],
     callback(error, status) { ... },
-    unused: "whatever"
+    unused: 'whatever'
   });
   ```
 

--- a/source/packages/modules.md
+++ b/source/packages/modules.md
@@ -11,7 +11,7 @@ We think you’re going to love the new module system, and that's why it will be
 
 For apps, this is as easy as `meteor add modules`, or (even better) `meteor add ecmascript`, since the `ecmascript` package *implies* the `modules` package.
 
-For packages, you can enable `modules` by adding `api.use("modules")` to the `Package.onUse` or `Package.onTest` sections of your `package.js` file.
+For packages, you can enable `modules` by adding `api.use('modules')` to the `Package.onUse` or `Package.onTest` sections of your `package.js` file.
 
 Now, you might be wondering what good the `modules` package is without the `ecmascript` package, since `ecmascript` enables `import` and `export` syntax. By itself, the `modules` package provides the CommonJS `require` and `exports` primitives that may be familiar if you’ve ever written Node code, and the `ecmascript` package simply compiles `import` and `export` statements to CommonJS. The `require` and `export` primitives also allow Node modules to run within Meteor application code without modification. Furthermore, keeping `modules` separate allows us to use `require` and `exports` in places where using `ecmascript` is tricky, such as the implementation of the `ecmascript` package itself.
 
@@ -30,9 +30,9 @@ First, you can `export` any named declaration on the same line where it was decl
 export var a = ...;
 export let b = ...;
 export const c = ...;
-export function d() {...}
-export function* e() {...}
-export class F {...}
+export function d() { ... }
+export function* e() { ... }
+export class F { ... }
 ```
 
 These declarations make the variables `a`, `b`, `c` (and so on) available not only within the scope of the `exporter.js` module, but also to other modules that `import` from `exporter.js`.
@@ -41,18 +41,18 @@ If you prefer, you can `export` variables by name, rather than prefixing their d
 
 ```js
 // exporter.js
-function g() {...}
+function g() { ... }
 let h = g();
 
-// at the end of the file
-export {g, h};
+// At the end of the file
+export { g, h };
 ```
 
 All of these exports are *named*, which means other modules can import them using those names:
 
 ```js
 // importer.js
-import {a, c, F, h} from "./exporter";
+import { a, c, F, h } from './exporter';
 new F(a, c).method(h);
 ```
 
@@ -60,14 +60,14 @@ If you’d rather use different names, you’ll be glad to know `export` and `im
 
 ```js
 // exporter.js
-export {g as x};
-g(); // same as calling y() in importer.js
+export { g as x };
+g(); // Same as calling `y()` in importer.js
 ```
 
 ```js
 // importer.js
-import {x as y} from "./exporter";
-y(); // same as calling g() in exporter.js
+import { x as y } from './exporter';
+y(); // Same as calling `g()` in exporter.js
 ```
 
 As with CommonJS `module.exports`, it is possible to define a single *default* export:
@@ -81,7 +81,7 @@ This default export may then be imported without curly braces, using any name th
 
 ```js
 // importer.js
-import Value from "./exporter";
+import Value from './exporter';
 // Value is identical to the exported expression
 ```
 
@@ -89,14 +89,14 @@ Unlike CommonJS `module.exports`, the use of default exports does not prevent th
 
 ```js
 // importer.js
-import Value, {a, F} from "./exporter";
+import Value, { a, F } from './exporter';
 ```
 
 In fact, the default export is conceptually just another named export whose name happens to be "default":
 
 ```js
 // importer.js
-import {default as Value, a, F} from "./exporter";
+import { default as Value, a, F } from './exporter';
 ```
 
 These examples should get you started with `import` and `export` syntax. For further reading, here is a very detailed [explanation](http://www.2ality.com/2014/09/es6-modules-final.html) by [Axel Rauschmayer](https://twitter.com/rauschma) of every variation of `import` and `export` syntax.
@@ -126,18 +126,18 @@ Note that files don’t need a `module.exports` if they’re required like `rout
 ES2015 `export` statements like these:
 
 ```js
-export const insert = new ValidatedMethod({ // ...
+export const insert = new ValidatedMethod({ ... });
 export default incompleteCountDenormalizer;
 ```
 
 can be rewritten to use CommonJS `module.exports`:
 
 ```js
-module.exports.insert = new ValidatedMethod({ // ...
+module.exports.insert = new ValidatedMethod({ ... });
 module.exports.default = incompleteCountDenormalizer;
 ```
 
-You can also simply write `exports` instead of `module.exports` if you prefer. If you need to `require` from an ES2015 module with a `default` export, you can access the export with `require("package").default`.
+You can also simply write `exports` instead of `module.exports` if you prefer. If you need to `require` from an ES2015 module with a `default` export, you can access the export with `require('package').default`.
 
 There is a case where you might *need* to use CommonJS, even if your project has the `ecmascript` package: if you want to conditionally include a module. `import` statements must be at top-level scope, so they cannot be within an `if` block. If you’re writing a common file, loaded on both client and server, you might want to import a module in only one or the other environment:
 
@@ -171,46 +171,46 @@ Before the release of Meteor 1.3, the only way to share values between files in 
 
 If you are familiar with modules in Node, you might expect modules not to be evaluated until the first time you import them. However, because earlier versions of Meteor evaluated all of your code when the application started, and we care about backwards compatibility, eager evaluation is still the default behavior.
 
-If you would like a module to be evaluated *lazily* (in other words: on demand, the first time you import it, just like Node does it), then you should put that module in an `imports/` directory (anywhere in your app, not just the root directory), and include that directory when you import the module: `import {stuff} from "./imports/lazy"`. Note: files contained by `node_modules/` directories will also be evaluated lazily (more on that below).
+If you would like a module to be evaluated *lazily* (in other words: on demand, the first time you import it, just like Node does it), then you should put that module in an `imports/` directory (anywhere in your app, not just the root directory), and include that directory when you import the module: `import {stuff} from './imports/lazy'`. Note: files contained by `node_modules/` directories will also be evaluated lazily (more on that below).
 
 Lazy evaluation will very likely become the default behavior in a future version of Meteor, but if you want to embrace it as fully as possible in the meantime, we recommend putting all your modules inside either `client/imports/` or `server/imports/` directories, with just a single entry point for each architecture: `client/main.js` and `server/main.js`. The `main.js` files will be evaluated eagerly, giving your application a chance to import modules from the `imports/` directories.
 
 ## Modular package structure
 
-If you are a package author, in addition to putting `api.use("modules")` or `api.use("ecmascript")` in the `Package.onUse` section of your `package.js` file, you can also use a new API called `api.mainModule` to specify the main entry point for your package:
+If you are a package author, in addition to putting `api.use('modules')` or `api.use('ecmascript')` in the `Package.onUse` section of your `package.js` file, you can also use a new API called `api.mainModule` to specify the main entry point for your package:
 
 ```js
 Package.describe({
-  name: "my-modular-package"
+  name: 'my-modular-package'
 });
 
 Npm.depends({
-  moment: "2.10.6"
+  moment: '2.10.6'
 });
 
-Package.onUse(function (api) {
-  api.use("modules");
-  api.mainModule("server.js", "server");
-  api.mainModule("client.js", "client");
-  api.export("Foo");
+Package.onUse((api) => {
+  api.use('modules');
+  api.mainModule('server.js', 'server');
+  api.mainModule('client.js', 'client');
+  api.export('Foo');
 });
 ```
 
 Now `server.js` and `client.js` can import other files from the package source directory, even if those files have not been added using the `api.addFiles` function.
 
-When you use `api.mainModule`, the exports of the main module are exposed globally as `Package["my-modular-package"]`, along with any symbols exported by `api.export`, and thus become available to any code that imports the package. In other words, the main module gets to decide what value of `Foo` will be exported by `api.export`, as well as providing other properties that can be explicitly imported from the package:
+When you use `api.mainModule`, the exports of the main module are exposed globally as `Package['my-modular-package']`, along with any symbols exported by `api.export`, and thus become available to any code that imports the package. In other words, the main module gets to decide what value of `Foo` will be exported by `api.export`, as well as providing other properties that can be explicitly imported from the package:
 
 ```js
-// In an application that uses my-modular-package:
-import {Foo as ExplicitFoo, bar} from "meteor/my-modular-package";
-console.log(Foo); // Auto-imported because of api.export.
-console.log(ExplicitFoo); // Explicitly imported, but identical to Foo.
+// In an application that uses 'my-modular-package':
+import { Foo as ExplicitFoo, bar } from 'meteor/my-modular-package';
+console.log(Foo); // Auto-imported because of `api.export`.
+console.log(ExplicitFoo); // Explicitly imported, but identical to `Foo`.
 console.log(bar); // Exported by server.js or client.js, but not auto-imported.
 ```
 
-Note that the `import` is `from "meteor/my-modular-package"`, not `from "my-modular-package"`. Meteor package identifier strings must include the prefix `meteor/...` to disambiguate them from npm packages.
+Note that the `import` is `from 'meteor/my-modular-package'`, not `from 'my-modular-package'`. Meteor package identifier strings must include the prefix `meteor/...` to disambiguate them from npm packages.
 
-Finally, since this package is using the new `modules` package, and the package `Npm.depends` on the "moment" npm package, modules within the package can `import moment from "moment"` on both the client and the server. This is great news, because previous versions of Meteor allowed npm imports only on the server, via `Npm.require`.
+Finally, since this package is using the new `modules` package, and the package `Npm.depends` on the "moment" npm package, modules within the package can `import moment from 'moment'` on both the client and the server. This is great news, because previous versions of Meteor allowed npm imports only on the server, via `Npm.require`.
 
 ## Local `node_modules`
 
@@ -221,7 +221,7 @@ meteor create modular-app
 cd modular-app
 mkdir node_modules
 npm install moment
-echo 'import moment from "moment";' >> modular-app.js
+echo "import moment from 'moment';" >> modular-app.js
 echo 'console.log(moment().calendar());' >> modular-app.js
 meteor
 ```
@@ -238,28 +238,28 @@ Thanks to modules, any load-order dependency you might imagine can be resolved b
 
 ```js
 // a.js
-import {bThing} from "./b";
-console.log(bThing, "in a.js");
+import { bThing } from './b';
+console.log(bThing, 'in a.js');
 ```
 
 ```js
 // b.js
-export var bThing = "a thing defined in b.js";
-console.log(bThing, "in b.js");
+export var bThing = 'a thing defined in b.js';
+console.log(bThing, 'in b.js');
 ```
 
 Sometimes a module doesn’t actually need to import anything from another module, but you still want to be sure the other module gets evaluated first. In such situations, you can use an even simpler `import` syntax:
 
 ```js
 // c.js
-import "./a";
-console.log("in c.js");
+import './a';
+console.log('in c.js');
 ```
 
 No matter which of these modules is imported first, the order of the `console.log` calls will always be:
 
 ```js
-console.log(bThing, "in b.js");
-console.log(bThing, "in a.js");
-console.log("in c.js");
+console.log(bThing, 'in b.js');
+console.log(bThing, 'in a.js');
+console.log('in c.js');
 ```

--- a/source/packages/oauth-encryption.md
+++ b/source/packages/oauth-encryption.md
@@ -9,7 +9,7 @@ login service's application secret key and users' access tokens.
 
 ## Generating a Key
 
-The encryption key is 16 bytes, encoded in base64.
+The encryption key is 16 bytes, encoded in Base64.
 
 To generate a key:
 
@@ -23,7 +23,7 @@ $ ~/.meteor/tools/latest/bin/node -e 'console.log(require("crypto").randomBytes(
 On the server only, use the `oauthSecretKey` option to `Accounts.config`:
 
 ```js
-Accounts.config({oauthSecretKey: "onsqJ+1e4iGFlV0nhZYobg=="});
+Accounts.config({ oauthSecretKey: 'onsqJ+1e4iGFlV0nhZYobg==' });
 ```
 
 This call to `Accounts.config` should be made at load time (place at
@@ -34,7 +34,7 @@ To avoid storing the secret key in your application's source code, you
 can use [`Meteor.settings`](http://docs.meteor.com/#meteor_settings):
 
 ```js
-Accounts.config({oauthSecretKey: Meteor.settings.oauthSecretKey});
+Accounts.config({ oauthSecretKey: Meteor.settings.oauthSecretKey });
 ```
 
 
@@ -47,22 +47,30 @@ token is encrypted.  The relevant fields in the service data are then
 encrypted.
 
 ```js
-Meteor.users.find({ $and: [
-    { 'services.twitter.accessToken': {$exists: true} },
-    { 'services.twitter.accessToken.algorithm': {$exists: false} }
-  ] }).
-forEach(function (userDoc) {
-  var set = {};
-  _.each(['accessToken', 'accessTokenSecret', 'refreshToken'], function (field) {
-    var plaintext = userDoc.services.twitter[field];
-    if (!_.isString(plaintext))
+const cursor = Meteor.users.find({
+  $and: [
+    { 'services.twitter.accessToken': { $exists: true } },
+    { 'services.twitter.accessToken.algorithm': { $exists: false } }
+  ]
+});
+
+cursor.forEach((userDoc) => {
+  const set = {};
+
+  ['accessToken', 'accessTokenSecret', 'refreshToken'].forEach((field) => {
+    const plaintext = userDoc.services.twitter[field];
+
+    if (!_.isString(plaintext)) {
       return;
-    set['services.twitter.' + field] = OAuthEncryption.seal(
-      userDoc.services.twitter[field],
+    }
+
+    set[`services.twitter.${field}`] = OAuthEncryption.seal(
+      plaintext,
       userDoc._id
     );
   });
-  Meteor.users.update(userDoc._id, {$set: set});
+
+  Meteor.users.update(userDoc._id, { $set: set });
 });
 ```
 
@@ -73,7 +81,7 @@ Meteor accounts packages, you can load the OAuth encryption key
 directly using `OAuthEncryption.loadKey`:
 
 ```js
-OAuthEncryption.loadKey("onsqJ+1e4iGFlV0nhZYobg==");
+OAuthEncryption.loadKey('onsqJ+1e4iGFlV0nhZYobg==');
 ```
 
 If you call `retrieveCredential` (such as
@@ -84,8 +92,8 @@ will be encrypted.
 You can decrypt them using `OAuth.openSecrets`:
 
 ```js
-var credentials = Twitter.retrieveCredential(token);
-var serviceData = OAuth.openSecrets(credentials.serviceData);
+const credentials = Twitter.retrieveCredential(token);
+const serviceData = OAuth.openSecrets(credentials.serviceData);
 ```
 
 ## Using oauth-encryption on Windows

--- a/source/packages/webapp.md
+++ b/source/packages/webapp.md
@@ -18,10 +18,10 @@ handling requests through `WebApp.connectHandlers`.
 Here's an example that will let you handle a specific URL:
 
 ```js
-// Listen to incoming HTTP requests, can only be used on the server
-WebApp.connectHandlers.use("/hello", function(req, res, next) {
+// Listen to incoming HTTP requests (can only be used on the server).
+WebApp.connectHandlers.use('/hello', (req, res, next) => {
   res.writeHead(200);
-  res.end("Hello world from: " + Meteor.release);
+  res.end(`Hello world from: ${Meteor.release}`);
 });
 ```
 


### PR DESCRIPTION
This pull request updates all code examples to use newer ECMAScript features and a more modern (and consistent) code style. If you think that I changed too much or if you prefer a different code style or formatting, I'd be happy to change it again, of course. :smile:

These are some of the changes I made:

* No more globals
* Arrow functions where `this` would be `window`/`global`. Publication functions, for example, still use `function`s, even if `this` isn't used.
* Shorter syntax for function definitions on object initializers
* More and consistent spacing to improve readability, for example using a space after opening and before closing braces for single line object literals.
* Single quotes instead of double quotes. The Guide and more recent code in the Docs also use single quotes.
* Template literals instead of string concatenation, except for multi-line strings where whitespace would be added at the beginning of each line.
* Camel case for publications, session variables, etc.
* Column size of 80 characters

Resolves #17