### PR TITLE
Use Object.assign instead of changing the argument

### DIFF
--- a/source/api/accounts-multi.md
+++ b/source/api/accounts-multi.md
@@ -159,14 +159,16 @@ Example:
 ```js
 // Support for playing D&D: Roll 3d6 for dexterity.
 Accounts.onCreateUser((options, user) => {
-  user.dexterity = _.random(1, 6) + _.random(1, 6) + _.random(1, 6);
+  const customizedUser = Object.assign({
+    dexterity: _.random(1, 6) + _.random(1, 6) + _.random(1, 6),
+  }, user);
 
   // We still want the default hook's 'profile' behavior.
   if (options.profile) {
-    user.profile = options.profile;
+    customizedUser.profile = options.profile;
   }
 
-  return user;
+  return customizedUser;
 });
 ```
 


### PR DESCRIPTION
To fully modernize this example and make it functional, I modified the function to use `Object.assign` to create a new user object to return instead of changing the passed in argument.

This could go one step further and change `options` to a destructured `{profile}` but there may be arguments against that. Let me know if you want me to destructure options.