### PR TITLE
add Tracker.inFlush() to documentation

### DIFF
--- a/source/api/tracker.md
+++ b/source/api/tracker.md
@@ -115,14 +115,14 @@ and returns `func`'s own return value.  If `func` accesses reactive data
 sources, these data sources will never cause a rerun of the enclosing
 computation.
 
-{% apibox "Tracker.inFlush" %}
-
-This value indicates, wether a flush is in progress or not.
-
 {% apibox "Tracker.active" %}
 
 This value is useful for data source implementations to determine
 whether they are being accessed reactively or not.
+
+{% apibox "Tracker.inFlush" %}
+
+This value indicates, wether a flush is in progress or not.
 
 {% apibox "Tracker.currentComputation" %}
 

--- a/source/api/tracker.md
+++ b/source/api/tracker.md
@@ -115,6 +115,10 @@ and returns `func`'s own return value.  If `func` accesses reactive data
 sources, these data sources will never cause a rerun of the enclosing
 computation.
 
+{% apibox "Tracker.inFlush" %}
+
+This value indicates, wether a flush is in progress or not.
+
 {% apibox "Tracker.active" %}
 
 This value is useful for data source implementations to determine


### PR DESCRIPTION
`Tracker.inFlush()` was added with meteor/meteor#8565