### PR TITLE
Fix syntax of function in HTTP.call example

### DIFF
--- a/source/api/http.md
+++ b/source/api/http.md
@@ -106,7 +106,7 @@ Example asynchronous HTTP call:
 ```js
 HTTP.call('POST', 'http://api.twitter.com/xyz', {
   data: { some: 'json', stuff: 1 }
-}, () => (error, result) {
+}, (error, result) => {
   if (!error) {
     Session.set('twizzled', true);
   }


### PR DESCRIPTION
Invalid syntax fixed in documentation of HTTP.call