### PR TITLE
Replace insecure `Session.get('myUserId')` in api/collections.md

### DIFF
--- a/source/api/collections.md
+++ b/source/api/collections.md
@@ -31,7 +31,7 @@ works on both the client and the server (see below).
 
 ```js
 // Return an array of my messages.
-const myMessages = Messages.find({ userId: Session.get('myUserId') }).fetch();
+const myMessages = Messages.find({ userId: Meteor.userId() }).fetch();
 
 // Create a new message.
 Messages.insert({ text: 'Hello, world!' });


### PR DESCRIPTION
One very small change, since I just came across it.

Removed the potentially insecure example of:
```
Messages.find({ userId: Session.get('myUserId') })
```
with the more secure (and non-Session):
```
Messages.find({ userId: Meteor.userId() })
```

We really don't want to accidentally encourage people to store the current `userId` in the `Session` global