### PR TITLE
Add note about 1.5.1's --extra-packages flag

### DIFF
--- a/source/packages/bundle-visualizer.md
+++ b/source/packages/bundle-visualizer.md
@@ -47,6 +47,13 @@ $ meteor add bundle-visualizer
 $ meteor --production
 ```
 
+If you have Meteor 1.5.1, you can use the `--extra-packages` flag, which will only add the visualizer package to your app temporily.
+
+```sh
+$ cd app/
+$ meteor --production --extra-packages bundle-visualizer
+```
+
 ### Viewing
 
 Once enabled, view the application in a web-browser as usual
@@ -61,3 +68,5 @@ application.
 ```sh
 $ meteor remove bundle-visualizer
 ```
+
+If you used the `--extra-packages` flag in Meteor 1.5.1, this step is not necessary.

--- a/source/packages/bundle-visualizer.md
+++ b/source/packages/bundle-visualizer.md
@@ -47,7 +47,7 @@ $ meteor add bundle-visualizer
 $ meteor --production
 ```
 
-If you have Meteor 1.5.1, you can use the `--extra-packages` flag, which will only add the visualizer package to your app temporily.
+If you have Meteor 1.5.1, you can use the `--extra-packages` flag, which will only add the visualizer package to your app temporarily.
 
 ```sh
 $ cd app/


### PR DESCRIPTION
One other thing that might be worth adding is to let people know to remove the `force-ssl` package. Otherwise the app keeps redirecting to https, which localhost doesn't seem to allow?