### PR TITLE
docs(packagejs): fix registerBuildPlugin link

### DIFF
--- a/source/api/packagejs.md
+++ b/source/api/packagejs.md
@@ -165,7 +165,7 @@ To register a linter build plugin in your package, you need to do a couple of
 things in your `package.js`:
 - depend on the `isobuild:linter-plugin@1.0.0` package
 - register a build plugin: `Package.registerBuildPlugin({ name, sources, ... });`
-  (see [docs](http://docs.meteor.com/#/full/Package-registerBuildPlugin))
+  (see [docs](http://docs.meteor.com/#/full/PackageNamespace#registerBuildPlugin))
 
 In your build plugin sources, register a Linter Plugin: provide details such as
 a name, list of extensions and filenames the plugin will handle and a factory
@@ -221,7 +221,7 @@ To register a compiler plugin in your package, you need to do the following in
 your `package.js` file:
 - depend on the `isobuild:compiler-plugin@1.0.0` package
 - register a build plugin: `Package.registerBuildPlugin({ name, sources, ... });`
-  (see [docs](http://docs.meteor.com/#/full/Package-registerBuildPlugin))
+  (see [docs](http://docs.meteor.com/#/full/PackageNamespace#registerBuildPlugin))
 
 In your build plugin source, register a Compiler Plugin: similar to other types
 of build plugins, provide the details, extensions and filenames and a factory
@@ -297,7 +297,7 @@ To register a minifier plugin in your package, add the following in your
 `package.js` file:
 - depend on `isobuild:minifier-plugin@1.0.0` package
 - register a build plugin: `Package.registerBuildPlugin({ name, sources, ... });`
-  (see [docs](http://docs.meteor.com/#/full/Package-registerBuildPlugin))
+  (see [docs](http://docs.meteor.com/#/full/PackageNamespace#registerBuildPlugin))
 
 In your build plugin source, register a Minifier Plugin. Similar to Linter and
 Compiler plugin, specify the interested extensions (`css` or `js`). The factory

--- a/source/api/packagejs.md
+++ b/source/api/packagejs.md
@@ -65,7 +65,7 @@ Npm.depends({
 `api.mainModule` is documented in the [modules](http://docs.meteor.com/packages/modules.html#Modular-package-structure) section.
 
 Build plugins are created with
-[`Package.registerBuildPlugin`](#Package-registerBuildPlugin). See the
+[`Package.registerBuildPlugin`](#PackageNamespace-registerBuildPlugin). See the
 coffeescript package for an example. Build plugins are fully-fledged Meteor
 programs in their own right and have their own namespace, package dependencies,
 source files and npm requirements.


### PR DESCRIPTION
This is supposed to link to:

```html
<a href="#PackageNamespace-registerBuildPlugin" class="link primary">
  <em>Package</em>.registerBuildPlugin([options])
</a>
```

![image](https://user-images.githubusercontent.com/5067638/28592196-0f3ab82a-713d-11e7-8b4e-d728eb8f3ef0.png)
