### PR TITLE
Update App.icons and App.launchScreens examples

### DIFF
--- a/source/api/mobile-config.md
+++ b/source/api/mobile-config.md
@@ -25,14 +25,14 @@ App.info({
 
 // Set up resources such as icons and launch screens.
 App.icons({
-  'iphone': 'icons/icon-60.png',
   'iphone_2x': 'icons/icon-60@2x.png',
+  'iphone_3x': 'icons/icon-60@3x.png',
   // More screen sizes and platforms...
 });
 
 App.launchScreens({
-  'iphone': 'splash/Default~iphone.png',
   'iphone_2x': 'splash/Default@2x~iphone.png',
+  'iphone5': 'splash/Default~iphone5.png',
   // More screen sizes and platforms...
 });
 


### PR DESCRIPTION
Update App.icons and App.launchScreens example code to match valid key values listed in detail sections below. The current `iphone` values give an invalid key warning during build.