### PR TITLE
collections: add warnings about allow/deny

### DIFF
--- a/jsdoc/jsdoc.sh
+++ b/jsdoc/jsdoc.sh
@@ -6,6 +6,9 @@ TOPDIR=$(pwd)
 METEOR_DIR="./code"
 cd "$METEOR_DIR"
 
+# Ensure that jsdoc failure actually makes this script fail.
+set -o pipefail
+
 # Call git grep to find all js files with the appropriate comment tags,
 # and only then pass it to JSDoc which will parse the JS files.
 # This is a whole lot faster than calling JSDoc recursively.

--- a/source/api/collections.md
+++ b/source/api/collections.md
@@ -391,6 +391,15 @@ Meteor.startup(() => {
 
 {% apibox "Mongo.Collection#allow" %}
 
+{% pullquote warning %}
+While `allow` and `deny` make it easy to get started building an app, it's
+harder than it seems to write secure `allow` and `deny` rules. We recommend
+that developers avoid `allow` and `deny`, and switch directly to custom methods
+once they are ready to remove `insecure` mode from their app.  See
+[the Meteor Guide on security](https://guide.meteor.com/security.html#allow-deny)
+for more details.
+{% endpullquote %}
+
 When a client calls `insert`, `update`, or `remove` on a collection, the
 collection's `allow` and [`deny`](#deny) callbacks are called
 on the server to determine if the write should be allowed. If at least
@@ -524,6 +533,15 @@ meteor remove insecure
 ```
 
 {% apibox "Mongo.Collection#deny" %}
+
+{% pullquote warning %}
+While `allow` and `deny` make it easy to get started building an app, it's
+harder than it seems to write secure `allow` and `deny` rules. We recommend
+that developers avoid `allow` and `deny`, and switch directly to custom methods
+once they are ready to remove `insecure` mode from their app.  See
+[the Meteor Guide on security](https://guide.meteor.com/security.html#allow-deny)
+for more details.
+{% endpullquote %}
 
 This works just like [`allow`](#allow), except it lets you
 make sure that certain writes are definitely denied, even if there is an


### PR DESCRIPTION
Note: jsdoc failed for me on a clean checkout with

```
ERROR: Unable to parse /Users/glasser/Projects/Meteor/docs/code/packages/ejson/ejson.js: 'import' and 'export' may only appear at the top level
```

I note that there wasn't a package-lock.json until I ran `npm install` so maybe we need to lock some transitive deps (as suggested by @abernix)?  I also added a line to jsdoc.sh so that jsdoc failures actually prevent the server from running.