### PR TITLE
Mobile: Re-configuring via App.configurePlugin may require manual intervention.

### DIFF
--- a/source/api/mobile-config.md
+++ b/source/api/mobile-config.md
@@ -76,6 +76,9 @@ App.accessRule('https://example.com', { type: 'navigation' });
 ```
 
 {% apibox "App.configurePlugin" %}
+
+> Note: When using `App.configurePlugin` to re-configure a plugin which has been previously configured, the changes may not be reflected without manually clearing the existing Cordova build.  To clear the existing Cordova build, remove the the `.meteor/local/cordova-build` directory and re-build the application using either `meteor run` or `meteor build`.
+
 {% apibox "App.icons" %}
 {% apibox "App.launchScreens" %}
 {% apibox "App.appendToConfig" %}

--- a/source/api/mobile-config.md
+++ b/source/api/mobile-config.md
@@ -77,7 +77,7 @@ App.accessRule('https://example.com', { type: 'navigation' });
 
 {% apibox "App.configurePlugin" %}
 
-> Note: When using `App.configurePlugin` to re-configure a plugin which has been previously configured, the changes may not be reflected without manually clearing the existing Cordova build.  To clear the existing Cordova build, remove the the `.meteor/local/cordova-build` directory and re-build the application using either `meteor run` or `meteor build`.
+> Note: When using `App.configurePlugin` to re-configure a plugin which has been previously configured, the changes may not be reflected without manually clearing the existing Cordova build.  To clear the existing Cordova build, remove the `.meteor/local/cordova-build` directory and re-build the application using either `meteor run` or `meteor build`.
 
 {% apibox "App.icons" %}
 {% apibox "App.launchScreens" %}


### PR DESCRIPTION
As discussed in https://github.com/meteor/meteor/issues/4234, re-configuring a plugin which has been previously configured with `App.configurePlugin` may require the `.meteor/local/cordova-build` directory to be manually cleared.

Closes #176.