### PR TITLE
Switch to using `chexo` to simplify the arguments for `hexo` commands.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -367,6 +367,76 @@
         "lodash": "4.17.5"
       }
     },
+    "chexo": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/chexo/-/chexo-1.0.3.tgz",
+      "integrity": "sha512-Gmeyp9ZHfF9MufrLKpX4xkGoMCq+MtRQn3Eg8fOhLvZwOmbMGeBHOsHxAIKwCjKzmkIR/c4swfGoJSy99aC6iw==",
+      "dev": true,
+      "requires": {
+        "hexo-cli": "1.0.4",
+        "minimist": "1.2.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
+        },
+        "hexo-cli": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/hexo-cli/-/hexo-cli-1.0.4.tgz",
+          "integrity": "sha512-X4YxBfuwRjCFF2fCAdmuLo/5IKruZCYc/kRaiVfPsTYFvvaBvsBTZBDhB8t4MOQv3QqoYMld9bGRLnd9NiEsFg==",
+          "dev": true,
+          "requires": {
+            "abbrev": "1.1.0",
+            "bluebird": "3.5.1",
+            "chalk": "1.1.3",
+            "command-exists": "1.2.2",
+            "hexo-fs": "0.2.2",
+            "hexo-log": "0.2.0",
+            "hexo-util": "0.6.3",
+            "minimist": "1.2.0",
+            "object-assign": "4.1.1",
+            "tildify": "1.2.0"
+          }
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
+        }
+      }
+    },
     "chokidar": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   },
   "devDependencies": {
     "canonical-json": "0.0.4",
+    "chexo": "^1.0.3",
     "handlebars": "4.0.11",
     "hexo": "3.5.0",
     "hexo-generator-archive": "0.1.5",
@@ -26,11 +27,11 @@
     "underscore": "1.8.3"
   },
   "scripts": {
-    "build": "jsdoc/jsdoc.sh && hexo generate --config ./node_modules/meteor-hexo-config/_config.yml,./_config.yml",
+    "build": "jsdoc/jsdoc.sh && chexo meteor-hexo-config -- generate",
     "clean": "hexo clean; rm data/data.js data/names.json",
     "test": "npm run clean; npm run build",
     "predeploy": "npm run build",
     "deploy": "hexo-s3-deploy",
-    "start": "npm run build && hexo server --config ./node_modules/meteor-hexo-config/_config.yml,./_config.yml"
+    "start": "npm run build && chexo meteor-hexo-config -- server"
   }
 }


### PR DESCRIPTION
I'm open to improving this newly created [`chexo`](https://npm.im) npm, but at
the very least, this makes the duplication of the `npm-scripts` across various
`package.json` files (in all the docs repositories) a bit more DRY.