### PR TITLE
Add minimal flag packages

### DIFF
--- a/source/commandline.md
+++ b/source/commandline.md
@@ -99,6 +99,10 @@ Creates a more complete, imports-based project which
 closely matches the [file structure](https://guide.meteor.com/structure.html#javascript-structure) recommended by the
 [Meteor Guide](https://guide.meteor.com/)
 
+`--minimal`
+
+Creates a project with as few Meteor Packages as possible.
+
  `--package`
 
 Creates a new package. If used in an
@@ -107,27 +111,30 @@ directory.
 
 **Packages**
 
-|| Default | `--bare`  | `--full`  |
+|| Default | `--bare`  | `--full`  | `--minimal` |
 |--------------------|--------|---|---|
-|[autopublish](https://atmospherejs.com/meteor/autopublish)|    X    |   |   |
-|[blaze-html-templates](https://atmospherejs.com/meteor/blaze-html-templates)| X | |X |
-|[ecmascript](https://atmospherejs.com/meteor/ecmascript)|X|X|X|
-|[es5-shim](https://atmospherejs.com/meteor/es5-shim)|X|X|X|
-|[insecure](https://atmospherejs.com/meteor/insecure)|X|||
-|[johanbrook:publication-collector](https://atmospherejs.com/meteor/johanbrook:publication-collector)|||X|
-|[kadira:blaze-layout](https://atmospherejs.com/meteor/kadira:blaze-layout)|||X|
-|[kadira:flow-router](https://atmospherejs.com/meteor/kadira:flow-router)|||X|
-|[less](https://atmospherejs.com/meteor/less)|||X|
-|[meteor-base](https://atmospherejs.com/meteor/meteor-base)|X|X|X|
-|[mobile-experience](https://atmospherejs.com/meteor/mobile-experience)|X|X|X|
-|[mongo](https://atmospherejs.com/meteor/mongo)|X|X|X|
-|[practicalmeteor:mocha](https://atmospherejs.com/meteor/practicalmeteor:mocha)|||X|
-|[reactive-var](https://atmospherejs.com/meteor/reactive-var)|X|X|X|
-|[shell-server](https://atmospherejs.com/meteor/shell-server)|X|X||
-|[standard-minifier-css](https://atmospherejs.com/meteor/standard-minifier-css)|X|X|X|
-|[standard-minifier-js](https://atmospherejs.com/meteor/standard-minifier-js)|X|X|X|
-|[static-html](https://atmospherejs.com/meteor/static-html)||X||
-|[tracker](https://atmospherejs.com/meteor/tracker)|X|X|X|
+|[autopublish](https://atmospherejs.com/meteor/autopublish)|    X    |   |   | |
+|[blaze-html-templates](https://atmospherejs.com/meteor/blaze-html-templates)| X | |X | |
+|[ecmascript](https://atmospherejs.com/meteor/ecmascript)|X|X|X|X|
+|[es5-shim](https://atmospherejs.com/meteor/es5-shim)|X|X|X|X|
+|[insecure](https://atmospherejs.com/meteor/insecure)|X||| |
+|[johanbrook:publication-collector](https://atmospherejs.com/meteor/johanbrook:publication-collector)|||X| |
+|[kadira:blaze-layout](https://atmospherejs.com/meteor/kadira:blaze-layout)|||X| |
+|[kadira:flow-router](https://atmospherejs.com/meteor/kadira:flow-router)|||X| |
+|[less](https://atmospherejs.com/meteor/less)|||X| |
+|[meteor](https://atmospherejs.com/meteor/meteor)||||X|
+|[meteor-base](https://atmospherejs.com/meteor/meteor-base)|X|X|X| |
+|[mobile-experience](https://atmospherejs.com/meteor/mobile-experience)|X|X|X| |
+|[mongo](https://atmospherejs.com/meteor/mongo)|X|X|X| |
+|[practicalmeteor:mocha](https://atmospherejs.com/meteor/practicalmeteor:mocha)|||X| |
+|[reactive-var](https://atmospherejs.com/meteor/reactive-var)|X|X|X| |
+|[server-render](https://atmospherejs.com/meteor/server-render)||||X|
+|[shell-server](https://atmospherejs.com/meteor/shell-server)|X|X||X|
+|[standard-minifier-css](https://atmospherejs.com/meteor/standard-minifier-css)|X|X|X|X|
+|[standard-minifier-js](https://atmospherejs.com/meteor/standard-minifier-js)|X|X|X|X|
+|[static-html](https://atmospherejs.com/meteor/static-html)||X||X|
+|[tracker](https://atmospherejs.com/meteor/tracker) |X|X|X| |
+|[webapp](https://atmospherejs.com/meteor/webapp) | | | |X|
 
 <h2 id="meteorloginlogout">meteor login / logout</h2>
 


### PR DESCRIPTION
Added the packages that I saw after creating a new project with 
`meteor create testProject --minimal` 
and then running 
`meteor list`

Output:
```
ecmascript             0.11.1* Compiler plugin that supports ES2015+ in all .js files
es5-shim               4.8.0  Shims and polyfills to improve ECMAScript 5 support
meteor                 1.9.2  Core Meteor environment
server-render          0.3.1  Generic support for server-side rendering in Meteor apps
shell-server           0.3.1* Server-side component of the `meteor shell` command.
standard-minifier-css  1.4.1* Standard css minifier used with Meteor apps by default.
standard-minifier-js   2.3.4* Standard javascript minifiers used with Meteor apps by default.
static-html            1.2.2  Define static page content in .html files
webapp                 1.6.2* Serves a Meteor app over HTTP

```