### PR TITLE
Fix CHANGELOG generator to accommodate breaking/migration steps in `v.NEXT`.

### DIFF
--- a/scripts/changelog.js
+++ b/scripts/changelog.js
@@ -9,6 +9,7 @@ var converter = new showdown.Converter({
 // Read the file given, strip of #vNEXT, render w/ markdown
 hexo.extend.tag.register('changelog', function(args) {
   var str = fs.readFileSync(args[0], 'utf8');
-  str = str.replace('## v.NEXT', '');
+  // Remove everything from `## v.NEXT` until the next H2 (released) heading.
+  str = str.replace(/^## v\.NEXT.*?^(?=##[^#])/ms, '');
   return converter.makeHtml(str);
 });


### PR DESCRIPTION
The Meteor docs use a RegExp to remove the `v.NEXT` section from the documentation, but the new `Breaking changes` and `Migration steps` blocks weren't being removed from the `v.NEXT` section, resulting in a weird look when I first bumped them to 1.8.0.2, as seen in this screenshot from #558's deploy preview:

https://c.jro.cc/722335ff832c

This should fix that!