### PR TITLE
fix a typo

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "hexo": {
-    "version": "3.8.0"
+    "version": "3.9.0"
   },
   "devDependencies": {
     "canonical-json": "0.0.4",

--- a/source/commandline.md
+++ b/source/commandline.md
@@ -39,7 +39,7 @@ For example: `NODE_OPTIONS='--debug'` or `NODE_OPTIONS='--debug-brk'`
 To specify a port to listen on (instead of the default 3000), use `--port [PORT]`.
 (The development server also uses port `N+1` for the default MongoDB instance)
 
-For example: `meteor run --port 4000` 
+For example: `meteor run --port 4000`
 will run the development server on `http://localhost:4000`
 and the development MongoDB instance on `mongodb://localhost:4001`.
 
@@ -112,7 +112,7 @@ directory.
 **Packages**
 
 || Default | `--bare`  | `--full`  | `--minimal` |
-|--------------------|--------|---|---|
+|--------------------|--------|---|---|---|
 |[autopublish](https://atmospherejs.com/meteor/autopublish)|    X    |   |   | |
 |[blaze-html-templates](https://atmospherejs.com/meteor/blaze-html-templates)| X | |X | |
 |[ecmascript](https://atmospherejs.com/meteor/ecmascript)|X|X|X|X|


### PR DESCRIPTION
This PR contains a fix for a a typo at `https://docs.meteor.com/commandline.html#meteorcreate`

On this page there's a table describing what packages are being included with available options.

Currently This is how it appears.
<img width="799" alt="Screenshot 2019-08-28 at 11 45 06 AM" src="https://user-images.githubusercontent.com/11193792/63830464-d30c1e00-c989-11e9-8b3a-af06d33f8455.png">

After this PR it will appear like this.
<img width="432" alt="Screenshot 2019-08-28 at 11 48 23 AM" src="https://user-images.githubusercontent.com/11193792/63830471-d69fa500-c989-11e9-967f-756b8eb48c04.png">

