### PR TITLE
Remove mention of underscore being included by default

### DIFF
--- a/source/packages/underscore.md
+++ b/source/packages/underscore.md
@@ -12,14 +12,6 @@ and the server.
 
 
 {% pullquote warning %}
-Currently, underscore is included in all projects, as the Meteor
-core depends on it. _ is available in the global namespace on both the
-client and the server even if you do not include this package. However
-if you do use underscore in your application, you should still add the
-package as we will remove the default underscore in the future.
-{% endpullquote %}
-
-{% pullquote warning %}
 We have slightly modified the way Underscore differentiates between
 objects and arrays in [collection functions](http://underscorejs.org/#each).
 The original Underscore logic is to treat any object with a numeric `length`


### PR DESCRIPTION
The _underscore_ package is not included by default since Meteor 1.7 (https://github.com/meteor/meteor/pull/9596), so this removes the mention of _underscore_ being included by default and `_` being in the global namespace.