### PR TITLE
Fix NODE_OPTIONS => SERVER_NODE_OPTIONS; --debug => --inspect

### DIFF
--- a/source/commandline.md
+++ b/source/commandline.md
@@ -33,8 +33,8 @@ required.
 This is the default command. Simply running `meteor` is the
 same as `meteor run`.
 
-To pass additional options to Node.js use the `NODE_OPTIONS` environment variable.
-For example: `NODE_OPTIONS='--debug'` or `NODE_OPTIONS='--debug-brk'`
+To pass additional options to Node.js use the `SERVER_NODE_OPTIONS` environment variable.
+For example: `SERVER_NODE_OPTIONS='--inspect'` or `SERVER_NODE_OPTIONS='--inspect-brk'`
 
 To specify a port to listen on (instead of the default 3000), use `--port [PORT]`.
 (The development server also uses port `N+1` for the default MongoDB instance)


### PR DESCRIPTION
Docs out of date. 
NODE_OPTIONS="--debug" results in following error message: "--debug is not allowed in NODE_OPTIONS"
Also, `--debug` is now invalid and `--inspect` should be used instead.