### PR TITLE
http package deprecation notice

### DIFF
--- a/source/api/http.md
+++ b/source/api/http.md
@@ -3,6 +3,8 @@ title: HTTP
 description: Documentation of Meteor's HTTP API.
 ---
 
+** `http` package has been deprecated. Please use the `fetch` package instead. **
+
 `HTTP` provides an HTTP request API on the client and server.  To use
 these functions, add the HTTP package to your project by running in your
 terminal:


### PR DESCRIPTION
Notice for `http` package docs about deprecation.

Better start this early as we start deprecating this across the board.

For more background: https://github.com/meteor/meteor/issues/10913