### PR TITLE
Added METEOR_PROFILE to Environment Variables documentation

### DIFF
--- a/source/environment-variables.md
+++ b/source/environment-variables.md
@@ -38,10 +38,13 @@ When running `meteor build` or `meteor deploy` you can set `METEOR_DISABLE_OPTIM
 
 Since optimistic in-memory caching is one of the more memory-intensive parts of the build system, setting the environment variable `METEOR_DISABLE_OPTIMISTIC_CACHING=1` can help improve memory usage during meteor build, which seems to improve the total build times. This configuration is perfectly safe because the whole point of optimistic caching is to keep track of previous results for future rebuilds, but in the case of meteor `build` or `deploy` there's only ever one initial build, so the extra bookkeeping is unnecessary.
 
+## METEOR_PROFILE
+(_development_)
+
+In development, you may need to diagnose what has made builds start taking a long time. To get the callstack and times during builds, you can run `METEOR_PROFILE=1 meteor`.
+
 ## METEOR_PACKAGE_DIRS
 (_development, production_)
-
-Colon-delimited list of local package directories to look in, outside your normal application structure, for example: `METEOR_PACKAGE_DIRS="/usr/local/my_packages/"`. Note that this used to be `PACKAGE_DIRS` but was changed in Meteor 1.4.2.
 
 ## METEOR_SETTINGS
 (_production_)

--- a/source/environment-variables.md
+++ b/source/environment-variables.md
@@ -46,6 +46,8 @@ In development, you may need to diagnose what has made builds start taking a lon
 ## METEOR_PACKAGE_DIRS
 (_development, production_)
 
+Colon-delimited list of local package directories to look in, outside your normal application structure, for example: `METEOR_PACKAGE_DIRS="/usr/local/my_packages/"`. Note that this used to be `PACKAGE_DIRS` but was changed in Meteor 1.4.2.
+
 ## METEOR_SETTINGS
 (_production_)
 


### PR DESCRIPTION
I added METEOR_PROFILE to environment variables page. This was useful in diagnosing what was causing rebuilds to take over 2 minutes.