### PR TITLE
Document EJSON support for regular expression and special numbers

### DIFF
--- a/source/api/ejson.md
+++ b/source/api/ejson.md
@@ -9,6 +9,8 @@ types, as well as:
  - **Date** (JavaScript `Date`)
  - **Binary** (JavaScript `Uint8Array` or the
    result of [`EJSON.newBinary`](#ejson_new_binary))
+ - **Special numbers** (JavaScript `NaN`, `Infinity`, and `-Infinity`)
+ - **Regular expressions** (JavaScript `RegExp`)
  - **User-defined types** (see [`EJSON.addType`](#ejson_add_type).  For example,
  [`Mongo.ObjectID`](#mongo_object_id) is implemented this way.)
 


### PR DESCRIPTION
The existing documentation didn't make it clear that `RegExp` objects could be encoded, though I imagined they could.  I updated the list of supported object types to include all those [defined by `builtinConverters`](https://github.com/meteor/meteor/blob/da7b08d4dd227fd3d297e90ede3b9735d73418f6/packages/ejson/ejson.js#L97).

I didn't give examples to show *how* these types are encoded.  I think the existing example suffices to give a flavor, and users can experiment to see what other things can be produced (including `$escape` in some cases).