### PR TITLE
Documentation for "--platforms" flag 

### DIFF
--- a/source/commandline.md
+++ b/source/commandline.md
@@ -414,6 +414,9 @@ This may cause difficulties if your app contains binary code due to,
 for example, npm packages. You can try to override that behavior
 with the `--architecture` flag.
 
+You can also specify which platforms you want to build with the `--platforms` flag.
+Examples: `--platforms=android`, `--platforms=ios`, `--platforms=web.browser`.
+
 
 <h2 id="meteorlint">meteor lint</h2>
 


### PR DESCRIPTION
Documentation for the `--platforms` flag from https://github.com/meteor/meteor/pull/11437.