### PR TITLE
Add small fetch and url documentation

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -58,6 +58,7 @@ sidebar_categories:
     - packages/coffeescript
     - packages/dynamic-import
     - packages/ecmascript
+    - packages/fetch
     - packages/hot-module-replacement
     - packages/less
     - packages/markdown
@@ -67,6 +68,7 @@ sidebar_categories:
     - packages/server-render
     - packages/spacebars
     - packages/underscore
+    - packages/url
     - packages/webapp
   Command Line:
     - commandline

--- a/source/packages/fetch.md
+++ b/source/packages/fetch.md
@@ -1,0 +1,62 @@
+---
+title: fetch
+description: Isomorphic modern/legacy/Node polyfill for WHATWG fetch().
+---
+
+This package replaces the `http` package for HTTP calls. `fetch` package provides polyfill for the [WHATWG fetch specification](https://fetch.spec.whatwg.org/) for legacy browsers or defaults to the global class which is available in modern browsers and Node. It is recomended that you use this package for compatibility with non-modern browsers.
+
+For more information we recommend [reading the MDN articles](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) about it as this article covers only basic usage in Meteor.
+
+## Usage
+### Installation
+To add this package to an existing app, run the following command from
+your app directory:
+
+```bash
+meteor add ecmascript
+```
+
+To add the `fetch` package to an existing package, include the
+statement `api.use('fetch');` in the `Package.onUse` callback in your
+`package.js` file:
+
+```js
+Package.onUse((api) => {
+  api.use('fetch');
+});
+```
+
+## API
+You can import `fetch`, `Headers`, `Request` and `Response` classes from `meteor/fetch`.
+
+```js
+import { fetch, Headers, Request, Response } from 'meteor/fetch';
+```
+
+For the most part though, you will only need to import `fetch` and `Headers`.
+
+```js
+import { Meteor } from 'meteor/meteor';
+import { fetch, Headers } from 'meteor/fetch';
+
+async function postData (url, data) {
+    const response = await fetch(url, {
+        method: 'POST', // *GET, POST, PUT, DELETE, etc.
+        mode: 'cors', // no-cors, *cors, same-origin
+        cache: 'no-cache', // *default, no-cache, reload, force-cache, only-if-cached
+        credentials: 'same-origin', // include, *same-origin, omit
+        headers: new Headers({
+            Authorization: 'Bearer my-secret-key',
+            'Content-Type': 'application/json'
+        }),
+        redirect: 'follow', // manual, *follow, error
+        referrerPolicy: 'no-referrer', // no-referrer, *no-referrer-when-downgrade, origin, origin-when-cross-origin, same-origin, strict-origin, strict-origin-when-cross-origin, unsafe-url
+        body: JSON.stringify(data) // body data type must match "Content-Type" header
+    });
+    return response.json();
+}
+
+const postDataCall = Meteor.wrapAsync(postData);
+const results = postDataCall('https://www.example.org/statsSubmission', { totalUsers: 55 }));
+
+```

--- a/source/packages/url.md
+++ b/source/packages/url.md
@@ -1,0 +1,64 @@
+---
+title: url
+description: Isomorphic modern/legacy/Node polyfill for WHATWG URL/URLSearchParams.
+---
+
+`url` package provides polyfill for the [WHATWG url specification](https://url.spec.whatwg.org/) for legacy browsers or defaults to the global class which is available in modern browsers and Node. It is recomended that you use this package for compatibility with non-modern browsers.
+
+For more information we recommend [reading the MDN articles](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) about it and looking over the [Node API documentation](https://nodejs.org/api/url.html#url_the_whatwg_url_api) for more details as this article covers only basic usage in Meteor.
+
+
+## Usage
+### Installation
+To add this package to an existing app, run the following command from
+your app directory:
+
+```bash
+meteor add url
+```
+
+To add the `url` package to an existing package, include the
+statement `api.use('url');` in the `Package.onUse` callback in your
+`package.js` file:
+
+```js
+Package.onUse((api) => {
+  api.use('url');
+});
+```
+
+After installing the package you can then import the `URL` and `URLSearchParams` from the package and use it as described at MDN and Node documentations.
+
+### URL
+```js
+import { URL } from 'meteor/url';
+
+const url = new URL('https://www.meteor.com');
+```
+
+You can then use `URL` for example in a [fetch](/packages/fetch) call:
+```js
+import { URL } from 'meteor/url';
+import { fetch } from 'meteor/fetch';
+
+const url = new URL('https://www.example.com/api/reportVisit');
+
+fetch(url, {
+    method: 'POST',
+    body: JSON.stringify({ siteId: 11 })
+    ...
+})
+
+```
+
+
+### URLSearchParams
+```js
+import { URLSearchParams } from 'meteor/url';
+
+const searchParams = new URLSearchParams({ query: 'WHATWG', location: 'MDN' })
+```
+
+You can then include `URLSearchParams` in the options for `URL` if you build them separately from when creating the `URL` class.
+
+


### PR DESCRIPTION
Per multiple requests I'm adding the initial documentation for `fetch` and `url` packages (since they are the same concept). It is no way near perfect, but I think this can serve as a nice base for further development.