### PR TITLE
Add example of how to rate limit per-connection

### DIFF
--- a/source/api/methods.md
+++ b/source/api/methods.md
@@ -233,5 +233,19 @@ const loginRule = {
 // Add the rule, allowing up to 5 messages every 1000 milliseconds.
 DDPRateLimiter.addRule(loginRule, 5, 1000);
 ```
+
+Here's another example that rate-limits adding a custom `threads.create` method per-connection:
+```js
+// Define a rule that matches login attempts by non-admin users.
+const threadCreateRule = {
+  type: 'method',
+  name: 'threads.create',
+  connectionId() {
+    return true;
+  }
+};
+// Add the rule, allowing up to 5 messages per user connection (i.e., every connection is rate-limited separately) every 30 minutes.
+DDPRateLimiter.addRule(threadCreateRule, 5, 1000 * 60 * 30);
+```
 {% apibox "DDPRateLimiter.removeRule" nested:true instanceDelimiter:. %}
 {% apibox "DDPRateLimiter.setErrorMessage" nested:true instanceDelimiter:. %}


### PR DESCRIPTION
I just got bitten by rate-limiter thinking by default the rule applies to each connection separately. This example should help educate users that it is not in fact the case unless you add `connectionId() { return true; }`.