### PR TITLE
Handle isprototype tag

### DIFF
--- a/jsdoc/docdata-jsdoc-template/publish.js
+++ b/jsdoc/docdata-jsdoc-template/publish.js
@@ -48,7 +48,7 @@
     if (entry.meta && entry.meta.path) {
       var packagesFolder = 'packages/';
       var index = entry.meta.path.indexOf(packagesFolder);
-      if (index != -1) {
+      if (index != -1 && !entry.isprototype) {
         var fullFilePath = entry.meta.path.substr(index + packagesFolder.length) + '/' + entry.meta.filename;
         entry.filepath = fullFilePath;
         entry.lineno = entry.meta.lineno;

--- a/scripts/api-box.js
+++ b/scripts/api-box.js
@@ -156,6 +156,7 @@ var importName = function(doc) {
   const noImportNeeded = !doc.module
     || doc.scope === 'instance'
     || doc.ishelper
+    || doc.isprototype
     || doc.istemplate;
 
   // override the above we've explicitly decided to (i.e. Template.foo.X)


### PR DESCRIPTION
Handle `@isprototype` tag.

When this tag is used, it assumes that the documentation in the code is for a prototype and that there is no implementation.

`apibox` will make  `importName` and `filepath` undefined for apis with the `@isprototype true` tag.

This is particularly useful for documenting callback function prototypes.